### PR TITLE
Dockerfile based on debian-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Two-stage build to reduce final image size
+# for more info see: https://docs.docker.com/build/building/multi-stage/
+
+# First build stage
+FROM rust:1.67 as builder
+WORKDIR /usr/src/fork-observer
+COPY . .
+RUN cargo install --path .
+
+# Second build stage
+FROM debian:bullseye-slim
+WORKDIR /fork-observer
+COPY --from=builder /usr/local/cargo/bin/fork-observer /fork-observer/fork-observer
+COPY --from=builder /usr/src/fork-observer/config.toml.example /fork-observer/config.toml
+COPY --from=builder /usr/src/fork-observer/www /fork-observer/www/
+ENV CONFIG_FILE=/fork-observer/config.toml
+CMD ["/fork-observer/fork-observer"]


### PR DESCRIPTION
This adds a Dockerfile which can in the future be used by a GH action to auto-build a docker image.

There appeared to be many potential optimisations for local dev, such as vendoring all dependencies to avoid rebuilding them if they haven't changed, but I didn't think this would help for a GH action.

It's also possible to base the image on alpine to shave another ~50MB off the image size, or if you want to get really thrifty base it off [docker scratch](https://hub.docker.com/_/scratch) (hooray, rust!), to save even more MB...

This additional [commit](https://github.com/0xB10C/fork-observer/commit/dad8c3faab9505c38bffcc803d6750a4b72d173c) shows a GH action to build and upload an image on pushed to main, and only build the image otherwise, along with the required changes which need to be made before it's functional on 0xB10C/fork-observer

Very open to critique on this one, as I'm a total Docker noob :)