### PR TITLE
Docker alpine image-based

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM rust:alpine3.18 as builder
+
+WORKDIR /app
+RUN apk add musl-dev
+
+COPY . .
+
+# target alpine linux
+RUN cargo install --path . --target=x86_64-unknown-linux-musl
+
+# second stage
+FROM alpine:3.18
+WORKDIR /app
+# copy over binary from first stage
+COPY --from=builder /usr/local/cargo/bin/fork-observer /usr/local/bin/
+COPY --from=builder /app/www ./www/
+
+CMD /usr/local/bin/fork-observer


### PR DESCRIPTION
Results in a 22MB image locally, which is compressed to 7.78MB on docker hub!

Needs a GH action commit added next to auto-build and push. This [commit](https://github.com/0xB10C/fork-observer/commit/b50a0d519af1ed6283bab6dccfbc323be32d7ef6) shows a GH action to build and upload an image on *pushes* to main, and only build the image otherwise (on pull requests).

You should change the tags `tags: will8clark/fork-observer:latest` to use your own docker hub username, and you'll need to add secrets to the GH repo:

```
DOCKERHUB_USERNAME 
DOCKERHUB_PASSWORD
```