### PR TITLE
change: use u32 to represent node id's instead of u8

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -76,7 +76,7 @@ impl fmt::Display for TomlNetwork {
 
 #[derive(Debug, Deserialize)]
 struct TomlNode {
-    id: u8,
+    id: u32,
     description: String,
     name: String,
     rpc_host: String,

--- a/src/node.rs
+++ b/src/node.rs
@@ -230,7 +230,7 @@ pub trait Node: Sync {
 
 #[derive(Hash, Clone)]
 pub struct NodeInfo {
-    pub id: u8,
+    pub id: u32,
     pub name: String,
     pub description: String,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,7 +25,7 @@ pub struct Cache {
     pub forks: Vec<Fork>,
 }
 
-pub type NodeData = BTreeMap<u8, NodeDataJson>;
+pub type NodeData = BTreeMap<u32, NodeDataJson>;
 pub type Caches = Arc<Mutex<BTreeMap<u32, Cache>>>;
 pub type TreeInfo = (DiGraph<HeaderInfo, bool>, HashMap<BlockHash, NodeIndex>);
 pub type Tree = Arc<Mutex<TreeInfo>>;
@@ -131,7 +131,7 @@ impl TipInfoJson {
 
 #[derive(Serialize, Clone)]
 pub struct NodeDataJson {
-    pub id: u8,
+    pub id: u32,
     pub name: String,
     pub description: String,
     pub tips: Vec<TipInfoJson>,


### PR DESCRIPTION
With u8's, up to 256 nodes were possible. Warnet might want to use more nodes. Using an u32 instead of an u8 significantly increases the theoretical maximum.

closes #22 