### PR TITLE
add: rss endpoint for invalid blocks

### DIFF
--- a/src/headertree.rs
+++ b/src/headertree.rs
@@ -168,7 +168,7 @@ pub async fn strip_tree(
     headers
 }
 
-// calculate the forks for rss
+// get recent forks for rss
 pub async fn recent_forks(tree: &Tree, how_many: usize) -> Vec<Fork> {
     let tree_locked = tree.lock().await;
     let tree = &tree_locked.0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,6 +361,13 @@ async fn main() -> Result<(), MainError> {
         .and(warp::query::<DataQuery>())
         .and_then(rss::forks_response);
 
+    let invalid_blocks_rss = warp::get()
+        .and(warp::path!("rss" / "invalid.xml"))
+        .and(api::with_caches(caches.clone()))
+        .and(api::with_networks(network_infos.clone()))
+        .and(warp::query::<DataQuery>())
+        .and_then(rss::invalid_blocks_response);
+
     let networks_json = warp::get()
         .and(warp::path!("api" / "networks.json"))
         .and(api::with_networks(network_infos))
@@ -388,7 +395,8 @@ async fn main() -> Result<(), MainError> {
         .or(info_json)
         .or(networks_json)
         .or(change_sse)
-        .or(forks_rss);
+        .or(forks_rss)
+        .or(invalid_blocks_rss);
 
     warp::serve(routes).run(config.address).await;
     Ok(())

--- a/src/types.rs
+++ b/src/types.rs
@@ -106,7 +106,7 @@ pub struct DataJsonResponse {
     pub nodes: Vec<NodeDataJson>,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Eq, Hash, PartialEq)]
 pub struct TipInfoJson {
     pub hash: String,
     pub status: String,

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -46,7 +46,7 @@ body, .card {
   background: var(--body-bg);
 }
 
-h1, h2, h3, h4, h5, h6, p, label, span, hr {
+h1, h2, h3, h4, h5, h6, p, label, span, hr, a {
   color: var(--text-color);
 }
 

--- a/www/index.html
+++ b/www/index.html
@@ -29,6 +29,15 @@
           <h3>Network: <span id="network_info_name"></span></h3>
           <span id="network_info_description"></span>
           <br>
+          <span>
+            <img src="static/img/rss-feed-white.svg" height=18>
+            <a target="_blank" id="rss_recent_forks">Recent forks</a>
+          </span>
+          <span>
+            <img src="static/img/rss-feed-white.svg" height=18>
+            <a target="_blank" id="rss_invalid_blocks">Invalid blocks</a>
+          </span>
+          <br>
           <details style="color: var(--text-color);" open>
             <summary>
               <span class="h4">Nodes</span>
@@ -43,12 +52,6 @@
         </div>
         <svg style="flex:1; flex-basis: 75vh; height:75vh;" class="border" id="drawing-area"></svg>
       </div>
-      <p>
-        <span>
-          <img src="static/img/rss-feed-white.svg" height=18>
-          <a target="_blank" id="rss_recent_forks">Recent forks</a>
-        </span>
-      </p>
     </main>
     <hr>
     <footer class="container-xxl px-xl-3 mt-3">

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -8,6 +8,7 @@ const networkInfoDescription = d3.select("#network_info_description")
 const networkInfoName = d3.select("#network_info_name")
 const footerCustom = d3.select("#footer-custom")
 const rssRecentForks = d3.select("#rss_recent_forks")
+const rssInvalidBlocks = d3.select("#rss_invalid_blocks")
 
 const SEARCH_PARAM_NETWORK = "network"
 
@@ -52,7 +53,8 @@ function update_network() {
   document.title = PAGE_NAME + " - " + current_network.name;
   networkInfoName.text(current_network.name)
   networkInfoDescription.text(current_network.description)
-  rssRecentForks.node().href = "/rss/forks.xml?network=" + current_network.id
+  rssRecentForks.node().href = "rss/forks.xml?network=" + current_network.id
+  rssInvalidBlocks.node().href = "rss/invalid.xml?network=" + current_network.id
 }
 
 function set_initial_network() {


### PR DESCRIPTION
contains output similar to e.g.

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<rss version="2.0">
<channel>
  <title>Invalid Blocks - Mainnet</title>
  <description>Recent invalid blocks on the Bitcoin Mainnet network</description>
  
  <item>
	<title>Invalid block at height 809478</title>
	<description>Invalid block 000000000000000000006840568a01091022093a176d12a1e8e5e261e4f11853 at height 809478 seen by node: Remote Node (id=0)</description>
	<guid>000000000000000000006840568a01091022093a176d12a1e8e5e261e4f11853</guid>
  </item>
  <item>
	<title>Invalid block at height 784121</title>
	<description>Invalid block 000000000000000000046a2698233ed93bb5e74ba7d2146a68ddb0c2504c980d at height 784121 seen by node: Remote Node (id=0)</description>
	<guid>000000000000000000046a2698233ed93bb5e74ba7d2146a68ddb0c2504c980d</guid>
  </item>
  <item>
	<title>Invalid block at height 783426</title>
	<description>Invalid block 00000000000000000002ec935e245f8ae70fc68cc828f05bf4cfa002668599e4 at height 783426 seen by node: Remote Node (id=0)</description>
	<guid>00000000000000000002ec935e245f8ae70fc68cc828f05bf4cfa002668599e4</guid>
  </item>
</channel>
</rss>
```
