### PR TITLE
add: test loading the example config file

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -6,8 +6,8 @@ database_path = "example_db_dir"
 # path to the location of the static www files
 www_path = "./www"
 
-# Interval for checking for new blocks
-query_interval = 10
+# Interval in seconds for checking for new blocks
+query_interval = 15
 
 # Webserver listen address
 address = "127.0.0.1:2323"
@@ -27,11 +27,11 @@ footer_html = """
   """
 
 [[networks]]
-id = 0x248281
-name = "Nikhils custom SigNet"
-description = "A custom SigNet with reorgs used for the development of the reorg-miner"
-min_fork_height = 5
-max_interesting_heights = 5
+id = 1
+name = "Mainnet"
+description = "An example mainnet node."
+min_fork_height = 0
+max_interesting_heights = 100
 
     [[networks.nodes]]
     id = 0
@@ -45,7 +45,7 @@ max_interesting_heights = 5
 
     [[networks.nodes]]
     id = 1
-    name = "Node R"
+    name = "Node B"
     description = "R node with a signet-miner that is always mining blocks"
     # rpc_cookie_file = "~/.bitcoin/.cookie"
     rpc_host = "127.0.0.1"
@@ -55,16 +55,16 @@ max_interesting_heights = 5
 
 [[networks]]
 id = 0xFFFFFFFE
-name = "FFFFFFFF testnetwork"
-description = "test"
+name = "FFFFFFFE testnetwork"
+description = "example"
 min_fork_height = 5
-max_interesting_heights = 5
+max_interesting_heights = 200
 
 
     [[networks.nodes]]
     id = 0
     name = "Node A"
-    description = "A node with a signet-miner that is always mining blocks"
+    description = "A node. Just A node."
     # rpc_cookie_file = "~/.bitcoin/.cookie"
     rpc_host = "127.0.0.1"
     rpc_port = 38342

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@ use serde::Deserialize;
 use crate::error::ConfigError;
 use crate::node::{BitcoinCoreNode, BtcdNode, Node, NodeInfo};
 
-const ENVVAR_CONFIG_FILE: &str = "CONFIG_FILE";
+pub const ENVVAR_CONFIG_FILE: &str = "CONFIG_FILE";
 const DEFAULT_CONFIG: &str = "config.toml";
 const DEFAULT_NODE_IMPL: NodeImplementation = NodeImplementation::BitcoinCore;
 const DEFAULT_USE_REST: bool = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -401,3 +401,24 @@ async fn main() -> Result<(), MainError> {
     warp::serve(routes).run(config.address).await;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn load_example_config() {
+        use crate::config;
+        use std::env;
+
+        const FILENAME_EXAMPLE_CONFIG: &str = "config.toml.example";
+        env::set_var(config::ENVVAR_CONFIG_FILE, FILENAME_EXAMPLE_CONFIG);
+        let cfg = config::load_config().expect(&format!(
+            "We should be able to load the {} file.",
+            FILENAME_EXAMPLE_CONFIG
+        ));
+
+        assert_eq!(cfg.address.to_string(), "127.0.0.1:2323");
+        assert_eq!(cfg.networks.len(), 2);
+        assert_eq!(cfg.query_interval, std::time::Duration::from_secs(15));
+    }
+}


### PR DESCRIPTION
This makes sure the `config.toml.example` file is up-to-date and that loading a configuration works.

Closes https://github.com/0xB10C/fork-observer/issues/14