### PR TITLE
RSS spec conforming RSS feeds

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -12,6 +12,11 @@ query_interval = 15
 # Webserver listen address
 address = "127.0.0.1:2323"
 
+# RSS feeds need a URL of the site. This is optional. If unset,
+# the RSS feeds might not be valid according to the RSS 2.0 specification.
+# Some RSS readers might complain.
+rss_base_url = "https://fork-observer.example.com/"
+
 # Custom footer for the site.
 footer_html = """
     <div class="my-2">

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,7 @@ struct TomlConfig {
     address: String,
     database_path: String,
     www_path: String,
+    rss_base_url: Option<String>,
     query_interval: u64,
     networks: Vec<TomlNetwork>,
     footer_html: String,
@@ -38,6 +39,7 @@ pub struct Config {
     pub address: SocketAddr,
     pub networks: Vec<Network>,
     pub footer_html: String,
+    pub rss_base_url: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -191,6 +193,7 @@ pub fn load_config() -> Result<Config, ConfigError> {
         query_interval: Duration::from_secs(toml_config.query_interval),
         address: SocketAddr::from_str(&toml_config.address)?,
         footer_html: toml_config.footer_html.clone(),
+        rss_base_url: toml_config.rss_base_url.unwrap_or_default().clone(),
         networks,
     })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -358,6 +358,7 @@ async fn main() -> Result<(), MainError> {
         .and(warp::path!("rss" / "forks.xml"))
         .and(api::with_caches(caches.clone()))
         .and(api::with_networks(network_infos.clone()))
+        .and(rss::with_rss_base_url(config.rss_base_url.clone()))
         .and(warp::query::<DataQuery>())
         .and_then(rss::forks_response);
 
@@ -365,6 +366,7 @@ async fn main() -> Result<(), MainError> {
         .and(warp::path!("rss" / "invalid.xml"))
         .and(api::with_caches(caches.clone()))
         .and(api::with_networks(network_infos.clone()))
+        .and(rss::with_rss_base_url(config.rss_base_url.clone()))
         .and(warp::query::<DataQuery>())
         .and_then(rss::invalid_blocks_response);
 

--- a/src/rss.rs
+++ b/src/rss.rs
@@ -23,7 +23,7 @@ impl fmt::Display for Item {
   <item>
 	<title>{}</title>
 	<description>{}</description>
-	<guid>{}</guid>
+	<guid isPermaLink="false">{}</guid>
   </item>"#,
             self.title, self.description, self.guid,
         )

--- a/src/rss.rs
+++ b/src/rss.rs
@@ -43,6 +43,7 @@ struct Channel {
     description: String,
     link: String,
     items: Vec<Item>,
+    href: String,
 }
 
 impl fmt::Display for Channel {
@@ -53,11 +54,13 @@ impl fmt::Display for Channel {
   <title>{}</title>
   <description>{}</description>
   <link>{}</link>
+  <atom:link href="{}" rel="self" type="application/rss+xml" />
   {}
 </channel>"#,
             self.title,
             self.description,
             self.link,
+            self.href,
             self.items.iter().map(|i| i.to_string()).collect::<String>(),
         )
     }
@@ -73,7 +76,7 @@ impl fmt::Display for Feed {
         write!(
             f,
             r#"<?xml version="1.0" encoding="UTF-8" ?>
-<rss version="2.0">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
 {}
 </rss>
 "#,
@@ -156,7 +159,8 @@ pub async fn forks_response(
                         network_name
                     )
                     .to_string(),
-                    link: base_url,
+                    link: base_url.clone(),
+                    href: format!("{}/rss/{}.xml?network={}", base_url, "forks", network_id),
                     items: cache.forks.iter().map(|f| f.clone().into()).collect(),
                 },
             };
@@ -214,7 +218,8 @@ pub async fn invalid_blocks_response(
                         "Recent invalid blocks on the Bitcoin {} network",
                         network_name
                     ),
-                    link: base_url,
+                    link: base_url.clone(),
+                    href: format!("{}/rss/{}.xml?network={}", base_url, "invalid", network_id),
                     items: invalid_blocks
                         .iter()
                         .map(|(tipinfo, nodes)| (*tipinfo, *nodes).into())


### PR DESCRIPTION
This tries to make the fork-observer RSS feeds valid according to the RSS 2.0 spec (using https://www.feedvalidator.org/). 

The newly added `rss_base_url` is optional and only required when actually using the RSS feeds (and needing valid RSS feeds).

closes https://github.com/0xB10C/fork-observer/issues/29