### PR TITLE
Basic pool identification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +64,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -361,6 +391,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
 name = "h2"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,7 +557,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -567,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -611,6 +647,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "minreq"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,9 +668,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "wasi",
@@ -658,6 +703,15 @@ checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi 0.2.6",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -706,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -807,6 +861,12 @@ dependencies = [
  "memchr",
  "smallvec",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustls-pemfile"
@@ -930,6 +990,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,26 +1062,26 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.5",
  "tokio-macros",
  "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "5973a027b341b462105675962214dfe3c938ad9afd395d84b28602608bdcec7b"
 dependencies = [
  "bech32",
  "bitcoin-internals",
- "bitcoin_hashes 0.13.0",
+ "bitcoin_hashes",
  "hex-conservative",
  "hex_lit",
  "secp256k1",
@@ -93,18 +93,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-private"
-version = "0.1.0"
+name = "bitcoin-pool-identification"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+checksum = "332a9b4709835bffb3f00b8f0b2907eadc795b7bfe94212dc94684d91f86e4bd"
 dependencies = [
- "bitcoin-private",
+ "bitcoin",
+ "hex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -262,6 +259,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
+ "bitcoin-pool-identification",
  "bitcoincore-rpc",
  "env_logger",
  "futures-util",
@@ -837,7 +835,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acea373acb8c21ecb5a23741452acd2593ed44ee3d343e72baaa143bc89d0d5"
 dependencies = [
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes",
  "rand",
  "secp256k1-sys",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,21 +64,31 @@ checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bech32"
-version = "0.9.1"
+version = "0.10.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
 
 [[package]]
 name = "bitcoin"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36f4c848f6bd9ff208128f08751135846cc23ae57d66ab10a22efff1c675f3c"
+checksum = "5973a027b341b462105675962214dfe3c938ad9afd395d84b28602608bdcec7b"
 dependencies = [
  "bech32",
- "bitcoin-private",
- "bitcoin_hashes",
+ "bitcoin-internals",
+ "bitcoin_hashes 0.13.0",
+ "hex-conservative",
  "hex_lit",
  "secp256k1",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+dependencies = [
  "serde",
 ]
 
@@ -95,16 +105,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals",
+ "hex-conservative",
  "serde",
 ]
 
 [[package]]
 name = "bitcoincore-rpc"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6c0ee9354e3dac217db4cb1dd31941073a87fe53c86bcf3eb2b8bc97f00a08"
+checksum = "8eb70725a621848c83b3809913d5314c0d20ca84877d99dd909504b564edab00"
 dependencies = [
- "bitcoin-private",
  "bitcoincore-rpc-json",
  "jsonrpc",
  "log",
@@ -114,12 +133,11 @@ dependencies = [
 
 [[package]]
 name = "bitcoincore-rpc-json"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d30ce6f40fb0a2e8d98522796219282504b7a4b14e2b4c26139a7bea6aec6586"
+checksum = "856ffbee2e492c23bca715d72ea34aae80d58400f2bda26a82015d6bc2ec3662"
 dependencies = [
  "bitcoin",
- "bitcoin-private",
  "serde",
  "serde_json",
 ]
@@ -435,6 +453,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
 
 [[package]]
 name = "hex_lit"
@@ -809,11 +833,11 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "secp256k1"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+checksum = "2acea373acb8c21ecb5a23741452acd2593ed44ee3d343e72baaa143bc89d0d5"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.12.0",
  "rand",
  "secp256k1-sys",
  "serde",
@@ -821,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+checksum = "4dd97a086ec737e30053fd5c46f097465d25bb81dd3608825f65298c4c98be83"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ log = { version = "0.4.17" }
 env_logger = { version = "0.9.0" }
 hex = { version = "0.4" }
 rusqlite = { version = "0.27.0", features = ["bundled"] }
-tokio = { version = "1", features = [ "rt-multi-thread", "time", "sync", "macros" ] }
+tokio = { version = "1.35", features = [ "rt-multi-thread", "time", "sync", "macros" ] }
 minreq = { version = "2.6.0", features = ["json-using-serde"] }
 tokio-stream = { version = "0.1.11", features = ["sync"] }
 futures-util = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 
-bitcoincore-rpc = "0.17.0"
+bitcoincore-rpc = "0.18.0"
 warp = "0.3"
 toml = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ petgraph = { version = "0.6.2", features = ["serde-1"] }
 base64 = "0.13.1"
 
 async-trait = "0.1.58"
+bitcoin-pool-identification = "0.3.1"
 
 [features]
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 For getting a good overview over different chain fork on the Bitcoin network,
 fork-observer ideally needs access to multiple Bitcoin Core nodes. It was
-designed work with many nodes on multiple networks in paralell. Additionally,
-if another party is willing to give you RPC access over e.g., an encryted
+designed work with many nodes on multiple networks in parallel. Additionally,
+if another party is willing to give you RPC access over e.g., an encrypted
 channel like wireguard, you can add their node to your fork-observer instance.
 This requires only access to three RPC calls that can be whitelisted. Note:
 Don't give anyone RPC access when your node is used to handle real-world funds.
@@ -16,7 +16,7 @@ connected to your Bitcoin Core node.
 fork-observer uses the Bitcoin Core RPC interface to query information about
 headers and the chain tips. The REST interface is used to query batches of
 main chain (the chain leading up to the chain tip) headers. Requesting block
-header batches via REST is way performanter than requesting them indivually
+header batches via REST is more performant than requesting them individually
 through RPC. While REST is optional, it's recommended to connect to at least
 a few nodes that have the RPC interface enabled. The REST interface can be
 disabled by setting `use_rest = false` in the per network node configuration
@@ -30,21 +30,23 @@ enables you to limit the allowed RPCs for this user.
 
 fork-observer needs access to the following RPCs:
 
-- `getchaintips`: Used to query avaliable chain tips and their status.
+- `getchaintips`: Used to query available chain tips and their status.
 - `getblockhash`: Used to query a block hash given a specific height.
 - `getblockheader`: Used to query (stale) block headers.
 - `getnetworkinfo` (optional): Used once during start-up query the Bitcoin Core
   version. This RPC could potentially expose private information about your
   nodes connectivity.
+- `getblock` (optional): Used for miner identification.
+
 
 A sample Bitcoin Core configuration could contain the following:
 
 ```config
 rpcauth=forkobserver:<password generated with rpcauth.py>
 
-rpcwhitelist=forkobserver:getchaintips,getblockheader,getblockhash
+rpcwhitelist=forkobserver:getchaintips,getblockheader,getblockhash,getblock
 # OR if you're fine with exposing getnetworkinfo
-# rpcwhitelist=forkobserver:getchaintips,getblockheader,getblockhash,getnetworkinfo
+# rpcwhitelist=forkobserver:getchaintips,getblockheader,getblockhash,getblock,getnetworkinfo
 
 # If you want to access *your* node's RPC interface via e.g. a wireguard tunnel
 # from some *other host*.

--- a/config.toml.example
+++ b/config.toml.example
@@ -37,6 +37,7 @@ name = "Mainnet"
 description = "An example mainnet node."
 min_fork_height = 0
 max_interesting_heights = 100
+pool_identification_network = "Mainnet"
 
     [[networks.nodes]]
     id = 0

--- a/config.toml.example
+++ b/config.toml.example
@@ -37,7 +37,9 @@ name = "Mainnet"
 description = "An example mainnet node."
 min_fork_height = 0
 max_interesting_heights = 100
-pool_identification_network = "Mainnet"
+    [networks.pool_identification]
+    enable = true
+    network = "Mainnet"
 
     [[networks.nodes]]
     id = 0
@@ -65,7 +67,8 @@ name = "FFFFFFFE testnetwork"
 description = "example"
 min_fork_height = 5
 max_interesting_heights = 200
-
+    [pool_identification]
+    enable = false
 
     [[networks.nodes]]
     id = 0

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,12 @@ pub struct Config {
     pub rss_base_url: String,
 }
 
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct PoolIdentification {
+    pub enable: bool,
+    pub network: Option<PoolIdentificationNetwork>,
+}
+
 #[derive(Debug, Deserialize)]
 struct TomlNetwork {
     id: u32,
@@ -68,7 +74,7 @@ struct TomlNetwork {
     min_fork_height: u64,
     max_interesting_heights: usize,
     nodes: Vec<TomlNode>,
-    pool_identification_network: Option<PoolIdentificationNetwork>,
+    pool_identification: Option<PoolIdentification>,
 }
 
 #[derive(Clone)]
@@ -79,7 +85,7 @@ pub struct Network {
     pub min_fork_height: u64,
     pub max_interesting_heights: usize,
     pub nodes: Vec<BoxedSyncSendNode>,
-    pub pool_identification_network: Option<PoolIdentificationNetwork>,
+    pub pool_identification: PoolIdentification,
 }
 
 impl fmt::Display for TomlNetwork {
@@ -229,7 +235,7 @@ fn parse_toml_network(
         min_fork_height: toml_network.min_fork_height,
         max_interesting_heights: toml_network.max_interesting_heights,
         nodes,
-        pool_identification_network: toml_network.pool_identification_network.clone(),
+        pool_identification: toml_network.pool_identification.clone().unwrap_or_default(),
     })
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -34,6 +34,15 @@ CREATE TABLE IF NOT EXISTS headers (
 )
 ";
 
+const UPDATE_STMT_HEADER_MINER: &str = "
+UPDATE
+    headers
+SET
+    miner = ?1
+WHERE
+    hash = ?2;
+";
+
 pub async fn setup_db(db: Db) -> Result<(), DbError> {
     db.lock().await.execute(CREATE_STMT_TABLE_HEADERS, [])?;
     Ok(())
@@ -71,6 +80,15 @@ pub async fn write_to_db(
         new_headers.len(),
         network
     );
+    Ok(())
+}
+
+pub async fn update_miner(db: Db, hash: &BlockHash, miner: String) -> Result<(), DbError> {
+    let mut db_locked = db.lock().await;
+    let tx = db_locked.transaction()?;
+
+    tx.execute(UPDATE_STMT_HEADER_MINER, [miner, hash.to_string()])?;
+    tx.commit()?;
     Ok(())
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use std::net::AddrParseError;
 use std::{error, io};
 
 use bitcoincore_rpc::bitcoin;
-use bitcoincore_rpc::bitcoin::hashes as bitcoin_hashes;
+use bitcoincore_rpc::bitcoin::hashes::hex::parse::HexToArrayError;
 
 #[derive(Debug)]
 pub enum FetchError {
@@ -216,7 +216,7 @@ pub enum JsonRPCError {
     RpcUnexpectedResponseContents(String),
     MinReq(minreq::Error),
     FromHex(hex::FromHexError),
-    BitcoinFromHex(bitcoin_hashes::hex::Error),
+    BitcoinFromHex(HexToArrayError),
     BitcoinDeserializeError(bitcoin::consensus::encode::Error),
     NotImplemented,
 }
@@ -273,8 +273,8 @@ impl From<bitcoin::consensus::encode::Error> for JsonRPCError {
     }
 }
 
-impl From<bitcoin_hashes::hex::Error> for JsonRPCError {
-    fn from(e: bitcoin::hashes::hex::Error) -> Self {
+impl From<HexToArrayError> for JsonRPCError {
+    fn from(e: HexToArrayError) -> Self {
         JsonRPCError::BitcoinFromHex(e)
     }
 }

--- a/src/headertree.rs
+++ b/src/headertree.rs
@@ -8,7 +8,7 @@ use crate::types::{Fork, HeaderInfoJson, Tree};
 
 use log::{info, warn};
 
-async fn sorted_interesting_heights(
+pub async fn sorted_interesting_heights(
     tree: &Tree,
     max_interesting_heights: usize,
     tip_heights: BTreeSet<u64>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
 
+use bitcoincore_rpc::bitcoin::Network;
 use bitcoincore_rpc::Error::JsonRpc;
 use env_logger::Env;
 use futures_util::StreamExt;
@@ -185,8 +186,19 @@ async fn main() -> Result<(), MainError> {
                     };
 
                     if last_tips != tips {
+                        let pool_identification_network = match network.pool_identification_network
+                        {
+                            Some(ref network) => network.to_network(),
+                            None => Network::Regtest,
+                        };
+
                         let new_headers: Vec<HeaderInfo> = match node
-                            .new_headers(&tips, &tree_clone, network.min_fork_height)
+                            .new_headers(
+                                &tips,
+                                &tree_clone,
+                                network.min_fork_height,
+                                pool_identification_network,
+                            )
                             .await
                         {
                             Ok(headers) => headers,

--- a/src/main.rs
+++ b/src/main.rs
@@ -387,13 +387,17 @@ async fn main() -> Result<(), MainError> {
         let db_clone2 = db_clone.clone();
         let network_clone = network.clone();
         task::spawn(async move {
-            let pool_identification_network = match network.pool_identification_network {
+            let pool_identification_network = match network.pool_identification.network {
                 Some(ref network) => network.to_network(),
                 None => Network::Regtest,
             };
             let pool_identification_data = default_data(pool_identification_network);
 
             while let Some(hash) = pool_id_rx.recv().await {
+                if !network_clone.pool_identification.enable {
+                    continue;
+                }
+
                 let idx: NodeIndex = {
                     let tree_locked = tree_clone.lock().await;
                     *tree_locked
@@ -576,5 +580,6 @@ mod tests {
         assert_eq!(cfg.address.to_string(), "127.0.0.1:2323");
         assert_eq!(cfg.networks.len(), 2);
         assert_eq!(cfg.query_interval, std::time::Duration::from_secs(15));
+        assert_eq!(cfg.networks[0].pool_identification.enable, true);
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -4,9 +4,10 @@ use std::fmt;
 use crate::error::{FetchError, JsonRPCError};
 use crate::types::{ChainTip, ChainTipStatus, HeaderInfo, Tree};
 
+use bitcoin_pool_identification::{default_data, PoolIdentification};
 use bitcoincore_rpc::bitcoin;
 use bitcoincore_rpc::bitcoin::blockdata::block::Header;
-use bitcoincore_rpc::bitcoin::BlockHash;
+use bitcoincore_rpc::bitcoin::{BlockHash, Transaction};
 use bitcoincore_rpc::Auth;
 use bitcoincore_rpc::Client;
 use bitcoincore_rpc::RpcApi;
@@ -28,12 +29,14 @@ pub trait Node: Sync {
     async fn block_header(&self, hash: &BlockHash) -> Result<Header, FetchError>;
     async fn block_hash(&self, height: u64) -> Result<BlockHash, FetchError>;
     async fn tips(&self) -> Result<Vec<ChainTip>, FetchError>;
+    async fn coinbase(&self, hash: &BlockHash) -> Result<Transaction, FetchError>;
 
     async fn new_headers(
         &self,
         tips: &Vec<ChainTip>,
         tree: &Tree,
         min_fork_height: u64,
+        network: bitcoin::Network,
     ) -> Result<Vec<HeaderInfo>, FetchError> {
         let mut new_headers: Vec<HeaderInfo> = Vec::new();
 
@@ -41,7 +44,7 @@ pub trait Node: Sync {
             self.new_active_headers(tips, tree, min_fork_height).await?;
         new_headers.append(&mut active_new_headers);
         let mut nonactive_new_headers: Vec<HeaderInfo> = self
-            .new_nonactive_headers(tips, tree, min_fork_height)
+            .new_nonactive_headers(tips, tree, min_fork_height, network)
             .await?;
         new_headers.append(&mut nonactive_new_headers);
         Ok(new_headers)
@@ -93,7 +96,7 @@ pub trait Node: Sync {
                     new_headers.push(HeaderInfo {
                         header: *height_header_pair.0,
                         height: height_header_pair.1 as u64,
-                        miner: "TODO: miner".to_string(),
+                        miner: "".to_string(),
                     });
 
                     if !already_knew_a_header {
@@ -104,127 +107,139 @@ pub trait Node: Sync {
                     }
                 }
 
-                    if already_knew_a_header {
-                        break;
-                    }
-
-                    query_height -= STEP_SIZE;
-                } else {
-                    let header_hash = self.block_hash(query_height as u64).await?;
-                    {
-                        let locked_tree = tree.lock().await;
-                        if locked_tree.1.contains_key(&header_hash) {
-                            break;
-                        }
-                    }
-                    let header = self.block_header(&header_hash).await?;
-                    new_headers.push(HeaderInfo {
-                        height: query_height as u64,
-                        header,
-                            miner: "TODO: miner".to_string(),
-                        });
-                        query_height -= 1;
-                    }
-
-                    if query_height < min_fork_height as i64 {
-                        break;
-                    }
+                if already_knew_a_header {
+                    break;
                 }
-                new_headers.sort_by_key(|h| h.height);
-                Ok(new_headers)
-            }
 
-            async fn new_nonactive_headers(
-                &self,
-                tips: &Vec<ChainTip>,
-                tree: &Tree,
-                min_fork_height: u64,
-            ) -> Result<Vec<HeaderInfo>, FetchError> {
-                let mut new_headers: Vec<HeaderInfo> = Vec::new();
-
-                for inactive_tip in tips
-                    .iter()
-                    .filter(|tip| tip.height - tip.branchlen as u64 > min_fork_height)
-                    .filter(|tip| tip.status != ChainTipStatus::Active)
+                query_height -= STEP_SIZE;
+            } else {
+                let header_hash = self.block_hash(query_height as u64).await?;
                 {
-                    let mut next_header = inactive_tip.block_hash();
-                    for i in 0..=inactive_tip.branchlen {
-                        {
-                            let tree_locked = tree.lock().await;
-                            if tree_locked.1.contains_key(&inactive_tip.block_hash()) {
-                                break;
-                            }
-                        }
-
-                        let height = inactive_tip.height - i as u64;
-                        debug!(
-                            "loading non-active-chain header: hash={}, height={}",
-                            next_header, height
-                        );
-
-                        let header = self.block_header(&next_header).await?;
-
-                    new_headers.push(HeaderInfo { height, header, miner: "TODO miner".to_string() });
-                    next_header = header.prev_blockhash;
+                    let locked_tree = tree.lock().await;
+                    if locked_tree.1.contains_key(&header_hash) {
+                        break;
+                    }
                 }
+                let header = self.block_header(&header_hash).await?;
+                new_headers.push(HeaderInfo {
+                    height: query_height as u64,
+                    header,
+                    miner: "".to_string(),
+                });
+                query_height -= 1;
             }
 
-            Ok(new_headers)
+            if query_height < min_fork_height as i64 {
+                break;
+            }
+        }
+        new_headers.sort_by_key(|h| h.height);
+        Ok(new_headers)
+    }
+
+    async fn new_nonactive_headers(
+        &self,
+        tips: &Vec<ChainTip>,
+        tree: &Tree,
+        min_fork_height: u64,
+        network: bitcoin::Network,
+    ) -> Result<Vec<HeaderInfo>, FetchError> {
+        let mut new_headers: Vec<HeaderInfo> = Vec::new();
+        let pools = default_data(network);
+        for inactive_tip in tips
+            .iter()
+            .filter(|tip| tip.height - tip.branchlen as u64 > min_fork_height)
+            .filter(|tip| tip.status != ChainTipStatus::Active)
+        {
+            let mut next_header = inactive_tip.block_hash();
+            for i in 0..=inactive_tip.branchlen {
+                {
+                    let tree_locked = tree.lock().await;
+                    if tree_locked.1.contains_key(&inactive_tip.block_hash()) {
+                        break;
+                    }
+                }
+
+                let height = inactive_tip.height - i as u64;
+                debug!(
+                    "loading non-active-chain header: hash={}, height={}",
+                    next_header, height
+                );
+
+                let header = self.block_header(&next_header).await?;
+                let mut miner = "Unknown".to_string();
+                if let Ok(coinbase) = self.coinbase(&next_header).await {
+                    miner = match coinbase.identify_pool(network, &pools) {
+                        Some(result) => result.pool.name,
+                        None => "Unknown".to_string(),
+                    };
+                }
+
+                new_headers.push(HeaderInfo {
+                    height,
+                    header,
+                    miner,
+                });
+                next_header = header.prev_blockhash;
+            }
         }
 
-        async fn active_chain_headers_rest(
-            &self,
-            count: u64,
-            start: BlockHash,
-        ) -> Result<Vec<Header>, FetchError> {
-            assert!(self.use_rest());
-            debug!(
-                "loading active-chain headers starting from {}",
-                start.to_string()
-            );
+        Ok(new_headers)
+    }
 
-            let url = format!(
-                "http://{}/rest/headers/{}/{}.bin",
-                self.rpc_url(),
-                count,
-                start
-            );
-            let res = minreq::get(url.clone()).with_timeout(8).send()?;
+    async fn active_chain_headers_rest(
+        &self,
+        count: u64,
+        start: BlockHash,
+    ) -> Result<Vec<Header>, FetchError> {
+        assert!(self.use_rest());
+        debug!(
+            "loading active-chain headers starting from {}",
+            start.to_string()
+        );
 
-            if res.status_code != 200 {
+        let url = format!(
+            "http://{}/rest/headers/{}/{}.bin",
+            self.rpc_url(),
+            count,
+            start
+        );
+        let res = minreq::get(url.clone()).with_timeout(8).send()?;
+
+        if res.status_code != 200 {
+            return Err(FetchError::BitcoinCoreREST(format!(
+                "could not load headers from REST URL ({}): {} {}: {:?}",
+                url,
+                res.status_code,
+                res.reason_phrase,
+                res.as_str(),
+            )));
+        }
+
+        let header_results: Result<
+            Vec<Header>,
+            bitcoincore_rpc::bitcoin::consensus::encode::Error,
+        > = res
+            .as_bytes()
+            .chunks(80)
+            .map(bitcoin::consensus::deserialize::<Header>)
+            .collect();
+
+        let headers = match header_results {
+            Ok(headers) => headers,
+            Err(e) => {
                 return Err(FetchError::BitcoinCoreREST(format!(
-                    "could not load headers from REST URL ({}): {} {}: {:?}",
-                    url,
-                    res.status_code,
-                    res.reason_phrase,
-                    res.as_str(),
-                )));
+                    "could not deserialize REST header response: {}",
+                    e
+                )))
             }
+        };
 
-            let header_results: Result<
-                Vec<Header>,
-                bitcoincore_rpc::bitcoin::consensus::encode::Error,
-            > = res
-                .as_bytes()
-                .chunks(80)
-                .map(bitcoin::consensus::deserialize::<Header>)
-                .collect();
-
-            let headers = match header_results {
-                Ok(headers) => headers,
-                Err(e) => {
-                    return Err(FetchError::BitcoinCoreREST(format!(
-                        "could not deserialize REST header response: {}",
-                        e
-                    )))
-                }
-            };
-
-            debug!(
-                "loaded {} active-chain headers starting from {}",
-                headers.len(),
-                start.to_string()
-            );
+        debug!(
+            "loaded {} active-chain headers starting from {}",
+            headers.len(),
+            start.to_string()
+        );
 
         Ok(headers)
     }
@@ -328,6 +343,22 @@ impl Node for BitcoinCoreNode {
         }
     }
 
+    async fn coinbase(&self, hash: &BlockHash) -> Result<Transaction, FetchError> {
+        let rpc = self.rpc_client()?;
+        let hash_clone = hash.clone();
+        match task::spawn_blocking(move || rpc.get_block(&hash_clone)).await {
+            Ok(result) => match result {
+                Ok(result) => Ok(result
+                    .txdata
+                    .first()
+                    .expect("Block should have a coinbase transaction")
+                    .clone()),
+                Err(e) => Err(e.into()),
+            },
+            Err(e) => Err(e.into()),
+        }
+    }
+
     async fn tips(&self) -> Result<Vec<ChainTip>, FetchError> {
         let rpc = self.rpc_client()?;
         match task::spawn_blocking(move || rpc.get_chain_tips()).await {
@@ -386,6 +417,23 @@ impl Node for BtcdNode {
             hash.to_string(),
         ) {
             Ok(header) => Ok(header),
+            Err(error) => Err(FetchError::BtcdRPC(error)),
+        }
+    }
+
+    async fn coinbase(&self, hash: &BlockHash) -> Result<Transaction, FetchError> {
+        let url = format!("http://{}/", self.rpc_url);
+        match crate::jsonrpc::btcd_block(
+            url,
+            self.rpc_user.clone(),
+            self.rpc_password.clone(),
+            hash.to_string(),
+        ) {
+            Ok(block) => Ok(block
+                .txdata
+                .first()
+                .expect("Block should have a coinbase transaction")
+                .clone()),
             Err(error) => Err(FetchError::BtcdRPC(error)),
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -19,6 +19,7 @@ use rusqlite::Connection;
 
 use tokio::sync::Mutex;
 
+#[derive(Clone)]
 pub struct Cache {
     pub header_infos_json: Vec<HeaderInfoJson>,
     pub node_data: NodeData,

--- a/src/types.rs
+++ b/src/types.rs
@@ -35,6 +35,7 @@ pub type Db = Arc<Mutex<Connection>>;
 pub struct HeaderInfo {
     pub height: u64,
     pub header: Header,
+    pub miner: String,
 }
 
 #[derive(Deserialize)]
@@ -76,6 +77,7 @@ pub struct HeaderInfoJson {
     pub time: u32,
     pub bits: u32,
     pub nonce: u32,
+    pub miner: String,
 }
 
 impl HeaderInfoJson {
@@ -91,6 +93,7 @@ impl HeaderInfoJson {
             time: hi.header.time,
             bits: hi.header.bits.to_consensus(),
             nonce: hi.header.nonce,
+            miner: hi.miner.clone(),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,6 +38,12 @@ pub struct HeaderInfo {
     pub miner: String,
 }
 
+impl HeaderInfo {
+    pub fn update_miner(&mut self, miner: String) {
+        self.miner = miner;
+    }
+}
+
 #[derive(Deserialize)]
 pub struct DataQuery {
     pub network: u32,

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -84,6 +84,12 @@ text.block-text {
  font-size: 10px;
 }
 
+text.block-miner {
+ fill: var(--text-color);
+ text-anchor: middle;
+ font-size: 10px;
+}
+
 .block {
   cursor: pointer;
 }

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -7,6 +7,7 @@
   --block-to-block-link-color: black;
   --block-description-link-color: gray;
   --block-description-bg: #f8f9fa;
+  --block-miner-color: rgb(122, 122, 122);
   --node-indicatior-stroke: black;
 }
 
@@ -20,6 +21,7 @@
     --block-description-link-color: lightgray;
     --block-description-bg: #f8f9fa;
     --node-indicatior-stroke: black;
+    --block-miner-color: rgb(172, 172, 172);
   }
   svg.invert, img.invert, .btn-close {
     -webkit-filter: invert(100%); /* safari 6.0 - 9.0 */
@@ -36,6 +38,7 @@
   --block-description-link-color: lightgray;
   --block-description-bg: #f8f9fa;
   --node-indicatior-stroke: black;
+  --block-miner-color: rgb(172, 172, 172);
   svg.invert, img.invert, .btn-close {
     -webkit-filter: invert(100%); /* safari 6.0 - 9.0 */
     filter: invert(100%);
@@ -85,7 +88,7 @@ text.block-text {
 }
 
 text.block-miner {
- fill: var(--text-color);
+ fill: var(--block-miner-color);
  text-anchor: middle;
  font-size: 10px;
 }

--- a/www/js/blocktree.js
+++ b/www/js/blocktree.js
@@ -9,12 +9,14 @@ const orientations = {
     y: (d, htoi) => -htoi[d.data.data.height] * NODE_SIZE,
     linkDir: (htoi) => d3.linkVertical().x(d => o.x(d, htoi)).y(d => o.y(d, htoi)),
     hidden_blocks_text: {offset_x: -45, offset_y: 0, anchor: "left"},
+    block_text_rotate: -90,
   },
   "left-to-right": {
     x: (d, htoi) => htoi[d.data.data.height] * NODE_SIZE,
     y: (d, _) => d.x,
     linkDir: (htoi) => d3.linkHorizontal().x(d => o.x(d, htoi)).y(d => o.y(d, htoi)),
     hidden_blocks_text: {offset_x: 0, offset_y: 15, anchor: "middle"},
+    block_text_rotate: 0,
   },
 };
 
@@ -271,9 +273,10 @@ function draw() {
   // miner next to the block
   blocks
     .append("text")
+    .attr("transform", `rotate(${o.block_text_rotate},0,0)`)
     .attr("dy", "4em")
     .attr("class", "block-miner")
-    .text(d => d.data.data.miner);
+    .text(d => d.data.data.miner.length > 14 ? d.data.data.miner.substring(0, 14) + "…" : d.data.data.miner);
 
   var node_groups = blocks
     .filter(d => d.data.data.status != "in-chain")

--- a/www/js/blocktree.js
+++ b/www/js/blocktree.js
@@ -231,10 +231,9 @@ function draw() {
                     <div class="row">
                       <span class="col-2">timestamp</span><span class="col-4">${d.data.data.time}</span>
                       <span class="col-2">version</span><span class="col-4 font-monospace">0x${d.data.data.version.toString(16)}</span>
-                    </div>
-                    <div class="row">
                       <span class="col-2">nonce</span><span class="col-4 font-monospace">0x${d.data.data.nonce.toString(16)}</span>
                       <span class="col-2">bits</span><span class="col-4 font-monospace">0x${d.data.data.bits.toString(16)}</span>
+                      <span class="col-2">miner</span><span class="col-4 font-monospace">${d.data.data.miner}</span>
                     </div>
                     <div class="row"><span class="col">${status_text}</span></div>
                   </div>
@@ -262,12 +261,19 @@ function draw() {
     .attr("stroke-width", "1")
     .attr("transform", "translate("+ (-block_size)/2  +", " + (-block_size)/2 + ")")
 
-  // text for the blocks
+  // height in the block
   blocks
     .append("text")
     .attr("dy", ".35em")
     .attr("class", "block-text")
     .text(d => d.data.data.height);
+
+  // miner next to the block
+  blocks
+    .append("text")
+    .attr("dy", "4em")
+    .attr("class", "block-miner")
+    .text(d => d.data.data.miner);
 
   var node_groups = blocks
     .filter(d => d.data.data.status != "in-chain")

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -105,6 +105,9 @@ changeSSE.addEventListener("tip_changed", (e) => {
   console.debug("server side event: the tip of one of the networks changed: ", data)
   if(data.network_id == state_selected_network_id) {
     console.debug("server side event: the tip of the currently displayed network changed: ", data)
+    // HACK: wait for 1 second before fetching data
+    // this gives the backend time to set the miner
+    delay(1000);
     update()
   }
 })


### PR DESCRIPTION
This adds optional pool identification by using the `getblock` RPC to query blocks and the https://crates.io/crates/bitcoin-pool-identification crate to identify pools. Blocks are queried and miners are updated in a separate thread.

This is a breaking change. It requires the database to be deleted. If the same nodes remain connected, no data should be lost as it's queried from the node again.

fixes: https://github.com/0xB10C/fork-observer/issues/28