### PR TITLE
change: improve RSS feed compatibility

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -3,20 +3,14 @@ use std::convert::Infallible;
 use warp::{sse::Event, Filter};
 
 use crate::types::{
-    Caches, DataChanged, DataJsonResponse, DataQuery, InfoJsonResponse, NetworkJson,
-    NetworksJsonResponse,
+    Caches, DataChanged, DataJsonResponse, InfoJsonResponse, NetworkJson, NetworksJsonResponse,
 };
 
 pub async fn info_response(footer: String) -> Result<impl warp::Reply, Infallible> {
     Ok(warp::reply::json(&InfoJsonResponse { footer }))
 }
 
-pub async fn data_response(
-    caches: Caches,
-    query: DataQuery,
-) -> Result<impl warp::Reply, Infallible> {
-    let network: u32 = query.network;
-
+pub async fn data_response(network: u32, caches: Caches) -> Result<impl warp::Reply, Infallible> {
     let caches_locked = caches.lock().await;
     match caches_locked.get(&network) {
         Some(cache) => Ok(warp::reply::json(&DataJsonResponse {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,9 +29,7 @@ mod node;
 mod rss;
 mod types;
 
-use types::{
-    Cache, Caches, ChainTip, DataQuery, Db, HeaderInfo, NetworkJson, NodeData, NodeDataJson, Tree,
-};
+use types::{Cache, Caches, ChainTip, Db, HeaderInfo, NetworkJson, NodeData, NodeDataJson, Tree};
 
 use crate::error::{DbError, MainError};
 
@@ -516,25 +514,22 @@ async fn main() -> Result<(), MainError> {
         .and_then(api::info_response);
 
     let data_json = warp::get()
-        .and(warp::path!("api" / "data.json"))
+        .and(warp::path!("api" / u32 / "data.json"))
         .and(api::with_caches(caches.clone()))
-        .and(warp::query::<DataQuery>())
         .and_then(api::data_response);
 
     let forks_rss = warp::get()
-        .and(warp::path!("rss" / "forks.xml"))
+        .and(warp::path!("rss" / u32 / "forks.xml"))
         .and(api::with_caches(caches.clone()))
         .and(api::with_networks(network_infos.clone()))
         .and(rss::with_rss_base_url(config.rss_base_url.clone()))
-        .and(warp::query::<DataQuery>())
         .and_then(rss::forks_response);
 
     let invalid_blocks_rss = warp::get()
-        .and(warp::path!("rss" / "invalid.xml"))
+        .and(warp::path!("rss" / u32 / "invalid.xml"))
         .and(api::with_caches(caches.clone()))
         .and(api::with_networks(network_infos.clone()))
         .and(rss::with_rss_base_url(config.rss_base_url.clone()))
-        .and(warp::query::<DataQuery>())
         .and_then(rss::invalid_blocks_response);
 
     let networks_json = warp::get()

--- a/src/rss.rs
+++ b/src/rss.rs
@@ -5,9 +5,7 @@ use warp::Filter;
 use std::collections::HashMap;
 use std::convert::Infallible;
 
-use crate::types::{
-    Caches, ChainTipStatus, DataQuery, Fork, NetworkJson, NodeDataJson, TipInfoJson,
-};
+use crate::types::{Caches, ChainTipStatus, Fork, NetworkJson, NodeDataJson, TipInfoJson};
 
 pub fn with_rss_base_url(
     base_url: String,
@@ -131,13 +129,11 @@ impl From<(&TipInfoJson, &Vec<NodeDataJson>)> for Item {
 }
 
 pub async fn forks_response(
+    network_id: u32,
     caches: Caches,
     network_infos: Vec<NetworkJson>,
     base_url: String,
-    query: DataQuery,
 ) -> Result<impl warp::Reply, Infallible> {
-    let network_id: u32 = query.network;
-
     let caches_locked = caches.lock().await;
     match caches_locked.get(&network_id) {
         Some(cache) => {
@@ -159,8 +155,8 @@ pub async fn forks_response(
                         network_name
                     )
                     .to_string(),
-                    link: base_url.clone(),
-                    href: format!("{}/rss/{}.xml?network={}", base_url, "forks", network_id),
+                    link: format!("{}?network={}", base_url.clone(), network_id),
+                    href: format!("{}/rss/{}/forks.xml", base_url, network_id),
                     items: cache.forks.iter().map(|f| f.clone().into()).collect(),
                 },
             };
@@ -174,13 +170,11 @@ pub async fn forks_response(
 }
 
 pub async fn invalid_blocks_response(
+    network_id: u32,
     caches: Caches,
     network_infos: Vec<NetworkJson>,
     base_url: String,
-    query: DataQuery,
 ) -> Result<impl warp::Reply, Infallible> {
-    let network_id: u32 = query.network;
-
     let caches_locked = caches.lock().await;
 
     match caches_locked.get(&network_id) {
@@ -218,8 +212,8 @@ pub async fn invalid_blocks_response(
                         "Recent invalid blocks on the Bitcoin {} network",
                         network_name
                     ),
-                    link: base_url.clone(),
-                    href: format!("{}/rss/{}.xml?network={}", base_url, "invalid", network_id),
+                    link: format!("{}?network={}", base_url.clone(), network_id),
+                    href: format!("{}/rss/{}/invalid.xml", base_url, network_id),
                     items: invalid_blocks
                         .iter()
                         .map(|(tipinfo, nodes)| (*tipinfo, *nodes).into())

--- a/src/types.rs
+++ b/src/types.rs
@@ -45,11 +45,6 @@ impl HeaderInfo {
     }
 }
 
-#[derive(Deserialize)]
-pub struct DataQuery {
-    pub network: u32,
-}
-
 #[derive(Serialize, Clone)]
 pub struct NetworkJson {
     pub id: u32,

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -30,7 +30,7 @@ async function fetch_info() {
 
 async function fetch_data() {
   console.debug("called fetch_data()")
-  await fetch('api/data.json?network='+networkSelect.node().value)
+  await fetch(`api/${state_selected_network_id}/data.json`)
     .then(response => response.json())
     .then(data => state_data = data)
     .catch(console.error);
@@ -53,8 +53,8 @@ function update_network() {
   document.title = PAGE_NAME + " - " + current_network.name;
   networkInfoName.text(current_network.name)
   networkInfoDescription.text(current_network.description)
-  rssRecentForks.node().href = "rss/forks.xml?network=" + current_network.id
-  rssInvalidBlocks.node().href = "rss/invalid.xml?network=" + current_network.id
+  rssRecentForks.node().href = `rss/${current_network.id}/forks.xml`
+  rssInvalidBlocks.node().href = `rss/${current_network.id}/invalid.xml`
 }
 
 function set_initial_network() {


### PR DESCRIPTION
Probelems:
1. Some RSS feed readers aren't compatible with the rss/[feed].xml?network=X query argument.
2. Some RSS feed readers seem to require an unique <link></link> value.

Solutions:
1. Change to rss/[X]/[feed].xml. To be consistent across the backend, also change the api/data.json?network=X to api/[X]/data.json.
2. Link to [base_url]?network=X (front-end) instead of just the base URL