### PR TITLE
Add: node reachabillity 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -304,6 +304,7 @@ async fn main() -> Result<(), MainError> {
                             &relevant_tips,
                             version_info.clone(),
                             last_change_timestamp,
+                            true, // here, the node was reachable
                         );
 
                         let forks = headertree::recent_forks(&tree_clone, MAX_FORKS_IN_CACHE).await;

--- a/src/types.rs
+++ b/src/types.rs
@@ -144,6 +144,8 @@ pub struct NodeDataJson {
     pub last_changed_timestamp: u64,
     /// The node subversion as advertised by the node on the network.
     pub version: String,
+    /// If the last getchaintips RPC reached the node.
+    pub reachable: bool,
 }
 
 impl NodeDataJson {
@@ -152,6 +154,7 @@ impl NodeDataJson {
         tips: &Vec<ChainTip>,
         version: String,
         last_changed_timestamp: u64,
+        reachable: bool,
     ) -> Self {
         NodeDataJson {
             id: info.id,
@@ -160,6 +163,7 @@ impl NodeDataJson {
             tips: tips.iter().map(TipInfoJson::new).collect(),
             last_changed_timestamp,
             version,
+            reachable,
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -166,6 +166,10 @@ impl NodeDataJson {
             reachable,
         }
     }
+
+    pub fn reachable(&mut self, r: bool) {
+        self.reachable = r;
+    }
 }
 
 #[derive(Serialize, Clone)]

--- a/www/index.html
+++ b/www/index.html
@@ -49,6 +49,10 @@
               <img src="static/img/rss-feed-white.svg" height=18>
               <a target="_blank" id="rss_lagging_nodes">Lagging nodes</a>
             </span>
+            <span>
+              <img src="static/img/rss-feed-white.svg" height=18>
+              <a target="_blank" id="rss_unreachable_nodes">Unreachable nodes</a>
+            </span>
           </p>
           <br>
           <details style="color: var(--text-color);" open>

--- a/www/js/blocktree.js
+++ b/www/js/blocktree.js
@@ -381,11 +381,26 @@ function node_description_summary(description) {
   return description
 }
 
+function get_active_height_or_0(node) {
+  let active_tips = node.tips.filter(tip => tip.status == "active")
+  if (active_tips.length > 0) {
+    return active_tips[0].height
+  }
+  return 0
+}
+
+function get_active_hash_or_fake(node) {
+  let active_tips = node.tips.filter(tip => tip.status == "active")
+  if (active_tips.length > 0) {
+    return active_tips[0].hash
+  }
+  return "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdead"
+}
 
 async function draw_nodes() {
   nodeInfoRow.html(null);
   nodeInfoRow.selectAll('.node-info')
-    .data(state_data.nodes.sort((a, b) => a.tips.filter(tip => tip.status == "active")[0].height - b.tips.filter(tip => tip.status == "active")[0].height))
+    .data(state_data.nodes.sort((a, b) => get_active_height_or_0(a) - get_active_height_or_0(b)))
     .enter()
     .append("div")
       .attr("class", "row-cols-auto px-1")
@@ -406,20 +421,20 @@ async function draw_nodes() {
           <span class="small">version: ${d.version}
         </div>
         <div class="px-2">
-          <span class="small">changed: ${new Date(d.last_changed_timestamp * 1000).toLocaleTimeString()}
+          <span class="small">changed: ${new Date(d.last_changed_timestamp * 1000).toLocaleString()}
         </div>
-        <div class="px-2" style="background-color: hsl(${parseInt(d.tips.filter(tip => tip.status == "active")[0].height * 90, 10) % 360}, 50%, 75%)">
-          <span class="small text-color-dark"> height: ${d.tips.filter(tip => tip.status == "active")[0].height}
+        <div class="px-2" style="background-color: hsl(${parseInt(get_active_height_or_0(d) * 90, 10) % 360}, 50%, 75%)">
+          <span class="small text-color-dark"> height: ${get_active_height_or_0(d)}
         </div>
-        <div class="px-2" style="background-color: hsl(${parseInt(d.tips.filter(tip => tip.status == "active")[0].hash.substring(58), 16) % 360}, 50%, 75%)">
+        <div class="px-2" style="background-color: hsl(${(parseInt(get_active_hash_or_fake(d).substring(58), 16) + 120) % 360}, 50%, 75%)">
           <details>
             <summary style="list-style: none;">
               <span class="small text-color-dark">
-                tip: …${d.tips.filter(tip => tip.status == "active")[0].hash.substring(54, 64)}
+                tip: …${get_active_hash_or_fake(d).substring(54, 64)}
               </span>
             </summary>
             <span class="small text-color-dark">
-              ${d.tips.filter(tip => tip.status == "active")[0].hash}
+              ${get_active_hash_or_fake(d)}
             </span>
           </details>
         </div>

--- a/www/js/blocktree.js
+++ b/www/js/blocktree.js
@@ -397,6 +397,37 @@ function get_active_hash_or_fake(node) {
   return "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdead"
 }
 
+function ago(timestamp) {
+  const rtf = new Intl.RelativeTimeFormat("en", {
+    style: "narrow",
+    numeric: "always",
+  });
+  const now = new Date()
+  const utc_seconds = (now.getTime() + now.getTimezoneOffset()*60) / 1000;
+  const seconds = timestamp - utc_seconds;
+  if (seconds > -90) {
+    return rtf.format(seconds, "seconds");
+  }
+  const minutes = parseInt(seconds/60);
+  if (minutes > -60) {
+    return rtf.format(minutes, "minutes");
+  }
+  const hours = parseInt(minutes/60);
+  if (hours > -24) {
+    return rtf.format(hours, "hours");
+  }
+  const days = parseInt(hours/60);
+  if (days > -30) {
+    return rtf.format(days, "days");
+  }
+  const months = parseInt(days/31);
+  if (months > -12) {
+    return rtf.format(months, "months");
+  }
+
+  return "a long time ago"
+}
+
 async function draw_nodes() {
   nodeInfoRow.html(null);
   nodeInfoRow.selectAll('.node-info')
@@ -405,32 +436,30 @@ async function draw_nodes() {
     .append("div")
       .attr("class", "row-cols-auto px-1")
       .html(d => `
-      <div class="col border rounded node-info my-1" style="min-height: 10rem; width: 16rem;">
-        <div class="m-2">
-          <h5 class="card-title py-0 my-0">
-            <span class="d-inline-block text-truncate" style="max-width: 15rem;">
-              <img class="invert" src="static/img/node.svg" height=28 alt="Node symbol">
-              ${d.name}
-            </span>
-          </h5>
-          <span>
-            ${node_description_summary(d.description)}
+      <div class="col border rounded node-info" style="min-height: 8rem; width: 16rem;">
+        <h5 class="card-title py-0 mt-1 mb-0">
+          <span class="mx-2 mt-1 d-inline-block text-truncate" style="max-width: 15rem;">
+            <img class="invert" src="static/img/node.svg" height=28 alt="Node symbol">
+            ${d.name}
           </span>
+        </h5>
+        <div class="px-2 small">
+          ${d.reachable ? "": "<span class='badge text-bg-danger'>RPC unreachable</span>"}
+          <span class='badge text-bg-secondary small'>${d.version.replaceAll("/", "").replaceAll("Satoshi:", "")}</span>
+          <span class="badge text-bg-secondary small">tip changed ${ago(d.last_changed_timestamp)}</span>
         </div>
+        
         <div class="px-2">
-          <span class="small">version: ${d.version}
-        </div>
-        <div class="px-2">
-          <span class="small">changed: ${new Date(d.last_changed_timestamp * 1000).toLocaleString()}
+          ${node_description_summary(d.description)}
         </div>
         <div class="px-2" style="background-color: hsl(${parseInt(get_active_height_or_0(d) * 90, 10) % 360}, 50%, 75%)">
           <span class="small text-color-dark"> height: ${get_active_height_or_0(d)}
         </div>
-        <div class="px-2" style="background-color: hsl(${(parseInt(get_active_hash_or_fake(d).substring(58), 16) + 120) % 360}, 50%, 75%)">
+        <div class="px-2 rounded-bottom" style="background-color: hsl(${(parseInt(get_active_hash_or_fake(d).substring(58), 16) + 120) % 360}, 50%, 75%)">
           <details>
             <summary style="list-style: none;">
               <span class="small text-color-dark">
-                tip: …${get_active_hash_or_fake(d).substring(54, 64)}
+                tip hash: …${get_active_hash_or_fake(d).substring(54, 64)}
               </span>
             </summary>
             <span class="small text-color-dark">

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -11,6 +11,7 @@ const connectionStatus = d3.select("#connection-status")
 const rssRecentForks = d3.select("#rss_recent_forks")
 const rssInvalidBlocks = d3.select("#rss_invalid_blocks")
 const rssLaggingNodes = d3.select("#rss_lagging_nodes")
+const rssUnreachableNodes = d3.select("#rss_unreachable_nodes")
 
 const SEARCH_PARAM_NETWORK = "network"
 
@@ -58,6 +59,7 @@ function update_network() {
   rssRecentForks.node().href = `rss/${current_network.id}/forks.xml`
   rssInvalidBlocks.node().href = `rss/${current_network.id}/invalid.xml`
   rssLaggingNodes.node().href = `rss/${current_network.id}/lagging.xml`
+  rssUnreachableNodes.node().href = `rss/${current_network.id}/unreachable.xml`
 }
 
 function set_initial_network() {


### PR DESCRIPTION
Keep track of current node reachability in the backend, show it in the frontend, fix an error in the frontend allowing for unreachable nodes to be displayed, add an RSS feed for unreachable nodes.

closes https://github.com/0xB10C/fork-observer/issues/19