### PR TITLE
refactor: big backend refactor

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,7 @@ const DEFAULT_CONFIG: &str = "config.toml";
 const DEFAULT_NODE_IMPL: NodeImplementation = NodeImplementation::BitcoinCore;
 const DEFAULT_USE_REST: bool = true;
 
-type BoxedSyncSendNode = Arc<dyn Node + Send + Sync>;
+pub type BoxedSyncSendNode = Arc<dyn Node + Send + Sync>;
 
 #[derive(Clone, Deserialize, Debug)]
 pub enum PoolIdentificationNetwork {

--- a/src/db.rs
+++ b/src/db.rs
@@ -6,7 +6,7 @@ use petgraph::graph::NodeIndex;
 use bitcoincore_rpc::bitcoin;
 use bitcoincore_rpc::bitcoin::BlockHash;
 
-use log::{info, warn};
+use log::{debug, info, warn};
 
 use crate::error::DbError;
 use crate::types::{Db, HeaderInfo, TreeInfo};
@@ -55,7 +55,7 @@ pub async fn write_to_db(
 ) -> Result<(), DbError> {
     let mut db_locked = db.lock().await;
     let tx = db_locked.transaction()?;
-    info!(
+    debug!(
         "inserting {} headers from network {} into the database..",
         new_headers.len(),
         network
@@ -75,7 +75,7 @@ pub async fn write_to_db(
         )?;
     }
     tx.commit()?;
-    info!(
+    debug!(
         "done inserting {} headers from network {} into the database",
         new_headers.len(),
         network

--- a/src/headertree.rs
+++ b/src/headertree.rs
@@ -1,12 +1,11 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
-use petgraph::graph::NodeIndex;
-use petgraph::visit::{Dfs, EdgeRef};
-
 use crate::types::{Fork, HeaderInfoJson, Tree};
 
-use log::{info, warn};
+use log::{debug, warn};
+use petgraph::graph::NodeIndex;
+use petgraph::visit::{Dfs, EdgeRef};
 
 pub async fn sorted_interesting_heights(
     tree: &Tree,
@@ -58,9 +57,9 @@ pub async fn sorted_interesting_heights(
     interesting_heights = interesting_heights_set
         .iter()
         .map(|h| *h)
-        .rev() // reversing: ascending -> desescending
+        .rev() // reversing: ascending -> descending
         .take(max_interesting_heights) // taking the 'last' max_interesting_heights
-        .rev() // reversing: desescending -> ascending
+        .rev() // reversing: descending -> ascending
         .collect();
 
     // To be sure, sort again.
@@ -94,10 +93,10 @@ pub async fn strip_tree(
         |_, edge| Some(edge),
     );
 
-    // We now have muliple sub header trees. To reconnect them
+    // We now have multiple sub header trees. To reconnect them
     // we figure out the starts of these chains (roots) and sort
     // them by height. We can't assume they are sorted when as we
-    // added data from mulitple nodes to the tree.
+    // added data from multiple nodes to the tree.
 
     let mut roots: Vec<NodeIndex> = striped_tree
         .externals(petgraph::Direction::Incoming)
@@ -110,7 +109,7 @@ pub async fn strip_tree(
 
     let mut prev_header_to_connect_to: Option<NodeIndex> = None;
     for root in roots.iter() {
-        // If we have apprev_header_to_connect_to, then connect
+        // If we have a prev_header_to_connect_to, then connect
         // the current root to it.
         if let Some(prev_idx) = prev_header_to_connect_to {
             striped_tree.add_edge(prev_idx, *root, &false);
@@ -134,7 +133,7 @@ pub async fn strip_tree(
         }
     }
 
-    info!(
+    debug!(
         "done collapsing tree: roots={}, tips={}",
         striped_tree
             .externals(petgraph::Direction::Incoming)
@@ -174,7 +173,7 @@ pub async fn recent_forks(tree: &Tree, how_many: usize) -> Vec<Fork> {
     let tree = &tree_locked.0;
 
     let mut forks: Vec<Fork> = vec![];
-    // it could be, that we have mutliple roots. To be safe, do this for all
+    // it could be, that we have multiple roots. To be safe, do this for all
     // roots.
     tree.externals(petgraph::Direction::Incoming)
         .for_each(|root| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,10 +40,7 @@ const VERSION_UNKNOWN: &str = "unknown";
 const MINER_UNKNOWN: &str = "Unknown";
 const MAX_FORKS_IN_CACHE: usize = 50;
 
-#[tokio::main]
-async fn main() -> Result<(), MainError> {
-    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
-
+async fn startup() -> Result<(config::Config, Db, Caches), MainError> {
     let config: config::Config = match config::load_config() {
         Ok(config) => {
             info!("Configuration loaded");
@@ -82,6 +79,13 @@ async fn main() -> Result<(), MainError> {
             return Err(e.into());
         }
     };
+    Ok((config, db, caches))
+}
+
+#[tokio::main]
+async fn main() -> Result<(), MainError> {
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+    let (config, db, caches) = startup().await?;
 
     // A channel to notify about tip changes via ServerSentEvents to clients.
     let (tipchanges_tx, _) = broadcast::channel(16);

--- a/src/main.rs
+++ b/src/main.rs
@@ -308,7 +308,7 @@ async fn main() -> Result<(), MainError> {
                             match tipchanges_tx_cloned.clone().send(network.id) {
                                 Ok(_) => debug!("Sent a tip_changed notification."),
                                 Err(e) => {
-                                    warn!(
+                                    debug!(
                                         "Could not send tip_changed update into the channel: {}",
                                         e
                                     )


### PR DESCRIPTION
- moves some main() functionallity in smaller functions, more needed work here
- refactors the cache updates: upadetes are now handled by update_cache()
- while at it, fixes a race condition between miner identification and strip_tree where the just identified miner would be overwritten with a strip_tree result