### PR TITLE
add: full screen page under /fullscreen

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -487,6 +487,9 @@ async fn main() -> Result<(), MainError> {
     let index_html = warp::get()
         .and(warp::path::end())
         .and(warp::fs::file(config.www_path.join("index.html")));
+    let fullscreen_html = warp::get()
+        .and(warp::path!("fullscreen"))
+        .and(warp::fs::file(config.www_path.join("fullscreen.html")));
 
     let info_json = warp::get()
         .and(warp::path!("api" / "info.json"))
@@ -549,6 +552,7 @@ async fn main() -> Result<(), MainError> {
 
     let routes = www_dir
         .or(index_html)
+        .or(fullscreen_html)
         .or(data_json)
         .or(info_json)
         .or(networks_json)

--- a/www/fullscreen.html
+++ b/www/fullscreen.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta name="color-scheme" content="dark light">
+  <meta charset="utf-8">
+  <title>fork-observer</title>
+  <meta name="author" content="">
+  <meta name="description" content="">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="static/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor">
+  <link href="static/css/style.css" rel="stylesheet">
+</head>
+
+<body>
+  <div class="container-fluid" style="display: flex; flex-direction: column; min-height: 100vh;">
+    <main style="flex: 1;">
+      <div style="display: flex; flex-direction: column;">
+        <svg style="flex:1; flex-basis: 98vh; height: 98vh;" id="drawing-area"></svg>
+        <div>
+          <label>Orientation <select name="orientation" id="orientation"></select></label>
+        </div>
+      </div>
+    </main>
+  </div>
+</body>
+
+<script src="static/js/d3.v7.min.js"></script>
+<script src="static/js/blocktree.js"></script>
+<script src="static/js/main.js"></script>
+</html>


### PR DESCRIPTION
Can be used for, for example, monitoring the halving.