### PR TITLE
Improve and refactor d3 animations and data bindings

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -106,12 +106,12 @@ text.block-miner {
   stroke: var(--text-color);
 }
 
-.node-indicator {
+.node-tip-status-indicator {
  stroke: var(--node-indicatior-stroke);
  stroke-width: 1px;
 }
 
-.node-indicator text {
+.node-tip-status-indicator text {
  stroke-width: 0px;
  font-size: 14px;
  text-anchor: middle;

--- a/www/js/blocktree.js
+++ b/www/js/blocktree.js
@@ -1,5 +1,6 @@
 const NODE_SIZE = 100
 const MAX_USIZE = 18446744073709551615;
+const BLOCK_SIZE = 50
 
 const orientationSelect = d3.select("#orientation")
 
@@ -8,7 +9,7 @@ const orientations = {
     x: (d, _) => d.x,
     y: (d, htoi) => -htoi[d.data.data.height] * NODE_SIZE,
     linkDir: (htoi) => d3.linkVertical().x(d => o.x(d, htoi)).y(d => o.y(d, htoi)),
-    hidden_blocks_text: {offset_x: -45, offset_y: 0, anchor: "left"},
+    hidden_blocks_text: {offset_x: -15, offset_y: 0, anchor: "left"},
     block_text_rotate: -90,
   },
   "left-to-right": {
@@ -20,8 +21,6 @@ const orientations = {
   },
 };
 
-let o = orientations["left-to-right"];
-
 const status_to_color = {
   "active": "lime",
   "invalid": "fuchsia",
@@ -29,6 +28,25 @@ const status_to_color = {
   "valid-headers": "red",
   "headers-only": "yellow",
 }
+
+// node status indicator
+const indicator_radius = 8
+const indicator_margin = 1
+
+let o = orientations["left-to-right"];
+
+let svg = d3
+    .select("#drawing-area")
+    .style("border", "1px solid")
+
+let initialDraw = true
+
+// enables zoom and panning
+const zoom = d3.zoom().scaleExtent([0.15, 2]).on( "zoom", e => g.attr("transform", e.transform) )
+svg.call(zoom)
+
+let g = svg
+    .append("g")
 
 function preprocess_data(data) {  
   let header_infos = data.header_infos;
@@ -99,218 +117,185 @@ function preprocess_data(data) {
 
 function draw() {
   let data = state_data
+  
+  // nothing to draw if there are no headers
+  if (data.header_infos.length == 0) {
+    return
+  }
+
   const [root_node, max_height, htoi] = preprocess_data(data)
 
-  var svg = d3
-    .select("#drawing-area")
-    .style("border", "1px solid")
-
-  svg.selectAll("*").remove()
-
-  // enables zoom and panning
-  const zoom = d3.zoom().scaleExtent([0.15, 2]).on( "zoom", e => g.attr("transform", e.transform) )
-  svg.call(zoom)
-
-  var g = svg
-    .append("g")
-
-  // links between the nodes
-  var links = g
+  let links = g
     .selectAll(".link-block-block")
-    .data(root_node.links())
-    .enter()
+    .data(root_node.links(), d => `${d.source.data.data.hash}-${d.target.data.data.hash}`)
+    .join(
+      enter => {
+        enter.append("path")
+          .attr("class", "link link-block-block")
+          .attr("d", o.linkDir(htoi))
+          .attr("stroke-dasharray", (d, x, y) => d.target.data.data.height - d.source.data.data.height == 1 ? y[x].getTotalLength() + " "  + y[x].getTotalLength() : "4 5")
+          .attr("fill", "transparent")
+          .attr("stroke-dashoffset", (d, x, y) => y[x].getTotalLength())
+          .attr("stroke-opacity", 1)
+          .classed("being-mined", d => d.target.data.data.status == "mining")
+          .transition(d3.transition().duration(300))
+          .attr("stroke-dashoffset", 0)
+          .attr("stroke-opacity", 0.2)
+          .transition(d3.transition().duration(300))
+          .attr("stroke-opacity", 1)
+      },
+      update => {
+        update
+          .transition(d3.transition().duration(600))
+          .attr("d", o.linkDir(htoi))
+          .attr("stroke-dasharray", (d, x, y) => d.target.data.data.height - d.source.data.data.height == 1 ? y[x].getTotalLength() + " "  + y[x].getTotalLength() : "4 5")
+          .attr("stroke-dashoffset", 0)
+          .attr("stroke-opacity", 1)
+      }
+    )
 
-  // <path> between blocks
-  links.append("path")
-    .attr("class", "link link-block-block")
-    .attr("d", o.linkDir(htoi))
-    .attr("stroke-dasharray", d => d.target.data.data.height - d.source.data.data.height == 1 ? "0" : "4 5")
-
-  // text for the not-shown blocks
-  var link_texts_hidden_blocks = links
-    .filter(d => d.target.data.data.height - d.source.data.data.height != 1)
-    .append("text")
-    .attr("class", "text-blocks-not-shown")
-    .style("text-anchor", o.hidden_blocks_text.anchor)
-    .style("font-size", "12px")
-    .attr("x", d => o.x(d.target, htoi) - ((o.x(d.target, htoi) - o.x(d.source, htoi))/2) + o.hidden_blocks_text.offset_x )
-    .attr("y", d => o.y(d.target, htoi) - ((o.y(d.target, htoi) - o.y(d.source, htoi))/2) + o.hidden_blocks_text.offset_y )
-  link_texts_hidden_blocks.append("tspan")
-    .text(d => (d.target.data.data.height - d.source.data.data.height -1) + " blocks")
-    .attr("dy", ".3em")
-  link_texts_hidden_blocks.append("tspan")
-    .text("hidden")
-    .attr("x", d => o.x(d.target, htoi) - ((o.x(d.target, htoi) - o.x(d.source, htoi))/2) + o.hidden_blocks_text.offset_x )
-    .attr("dy", "1em")
+  let hiddenBlockTexts = g
+    .selectAll(".text-blocks-not-shown")
+    .data(root_node.links().filter(d => d.target.data.data.height - d.source.data.data.height != 1), d => d.source.data.data.hash + d.target.data.data.hash)
+    .join(
+      enter => {
+        let blocksNotShown = enter.append("text")
+          .attr("class", "text-blocks-not-shown")
+          .style("text-anchor", o.hidden_blocks_text.anchor)
+          .style("font-size", "12px")
+          .attr("x", d => o.x(d.target, htoi) - ((o.x(d.target, htoi) - o.x(d.source, htoi))/2) + o.hidden_blocks_text.offset_x )
+          .attr("y", d => o.y(d.target, htoi) - ((o.y(d.target, htoi) - o.y(d.source, htoi))/2) + o.hidden_blocks_text.offset_y )
+          .attr("transform", d => `rotate(${o.block_text_rotate}, ${o.x(d.target, htoi) - ((o.x(d.target, htoi) - o.x(d.source, htoi))/2) + o.hidden_blocks_text.offset_x},${o.y(d.target, htoi) - ((o.y(d.target, htoi) - o.y(d.source, htoi))/2) + o.hidden_blocks_text.offset_y})`)
+        
+        blocksNotShown.append("tspan")
+          .text(d => (d.target.data.data.height - d.source.data.data.height -1) + " blocks hidden")
+          .attr("dy", ".3em")
+        return blocksNotShown
+      },
+      update => {
+        update
+          .transition(d3.transition().duration(600))
+          .attr("x", d => o.x(d.target, htoi) - ((o.x(d.target, htoi) - o.x(d.source, htoi))/2) + o.hidden_blocks_text.offset_x )
+          .attr("y", d => o.y(d.target, htoi) - ((o.y(d.target, htoi) - o.y(d.source, htoi))/2) + o.hidden_blocks_text.offset_y )
+          .attr("transform", d => `rotate(${o.block_text_rotate}, ${o.x(d.target, htoi) - ((o.x(d.target, htoi) - o.x(d.source, htoi))/2) + o.hidden_blocks_text.offset_x},${o.y(d.target, htoi) - ((o.y(d.target, htoi) - o.y(d.source, htoi))/2) + o.hidden_blocks_text.offset_y})`)
+      }
+    )
 
   // adds each block as a group
-  var blocks = g
-    .selectAll(".block-group")
-    .data(root_node.descendants())
-    .enter()
-    .append("g")
-    .attr("class", d => "block" + (d.children ? " block--internal" : " block--leaf"))
-    .attr("transform", d => "translate(" + o.x(d, htoi) + "," + o.y(d, htoi) + ")")
-    .on("click", (c, d) => onBlockClick(c, d))
+  let blocks = g
+    .selectAll(".block")
+    .data(root_node.descendants(), d => `${d.data.data.hash}-${d.data.data.height}`)
+    .join(
+      enter => {
+        let newBlocks = enter.append("g")
+          .classed("block", true)
+          .attr("id", d => "block-" + d.data.data.height + "-" + d.data.data.hash)
+          .attr("transform", d => "translate(" + o.x(d, htoi) + "," + o.y(d, htoi) + ")")
+          .attr("x", d => o.x(d, htoi))
+          .attr("y", d => o.y(d, htoi))
+          .on("click", (c, d) => onBlockClick(c, d))
+        
+        let block_child_group = newBlocks.append("g")
+          .attr("class", "block-child-group")
 
-  function onBlockClick(c, d) {
-    let parentElement = d3.select(c.target.parentElement)
+        let block_backgrounds = block_child_group.insert("rect")
+          .attr("rx", 5)
+          .attr("fill", "white")
+          .attr("stroke", "lightgray")
+          .attr("stroke-opacity", d => d.data.data.status == "mining" ? 0.2 : 1)
+          .classed("being-mined", d => d.data.data.status == "mining")
+          
+        block_backgrounds.filter(d => d.data.data.height != max_height || initialDraw)
+          .attr("x", -BLOCK_SIZE/2)
+          .attr("y", -BLOCK_SIZE/2)
+          .attr("height", d => BLOCK_SIZE)
+          .attr("width", d => BLOCK_SIZE)
+        
+        let height_text = block_child_group
+          .insert("text")
+          .attr("dy", ".35em")
+          .attr("class", "block-text")
+          .text(d => d.data.data.height);
+        
+        let pool_text = block_child_group
+          .insert("text")
+          .classed("block-pool-name", true)
+          .attr("transform", `rotate(${o.block_text_rotate},0,0)`)
+          .attr("dy", "4em")
+          .classed("block-miner", true)
+          .text(d => d.data.data.miner.length > 14 ? d.data.data.miner.substring(0, 14) + "…" : d.data.data.miner);
 
-    // The on-click listener of the block propagates to the appened description elements.
-      // To prevent adding a second description element of the block we return early if the
-      // parentElement is not the block.
-      if (parentElement.attr("class") == null || !parentElement.attr("class").startsWith("block block--")) return
+        newBlocks
+          .append('path')
+          .attr("class", "link link-block-description") // when modifying, check if there is a depedency on this class name.
+     
+        if (!initialDraw) {
+          block_backgrounds
+            .filter(d => d.data.data.height == max_height)
+            .attr("transform", "scale(0.1)")
+            .attr("height", d => BLOCK_SIZE)
+            .attr("width", d => BLOCK_SIZE)
+            .transition(d3.transition().duration(600))
+            .attr("x", -BLOCK_SIZE/2)
+            .attr("y", -BLOCK_SIZE/2)
+            .attr("transform", "scale(1)")
 
-      if (parentElement.selectAll(".block-description").size() > 0) {
-        parentElement.selectAll(".block-description").remove()
-        parentElement.selectAll(".link-block-description").attr("d", "")
-      } else {
+          pool_text
+            .filter(d => d.data.data.height == max_height)
+            .style("opacity", 0)
+            .transition(d3.transition().duration(600))
+            .style("opacity", 1)
 
-        const description_offset = { x: 50, y: -50 }
-        const description_margin = { x: 0, y: 15 }
-        let descGroup = parentElement.append("g")
-          .attr("class", "block-description")
-          .attr("transform", "translate(" + description_offset.x + "," + description_offset.y / 2 + ")")
-          .each(d => { d.x = description_offset.x; d.y = description_offset.y })
-          .call(
-            d3.drag()
-              .on("start", dragstarted)
-              .on("drag", dragged)
-              .on("end", dragended)
-          )
-
-        parentElement.raise()
-
-        function dragstarted() {d3.select(this).raise().attr("cursor", "grabbing");}
-        function dragged(event, d) {
-          d.x += event.dx;
-          d.y += event.dy;
-          var link = d3.linkHorizontal()({
-            source: [ 0, 0 ],
-            target: [
-              d.x + (card.node().getBoundingClientRect().width  / d3.zoomTransform(svg.node()).k) / 2,
-              d.y + (card.node().getBoundingClientRect().height / d3.zoomTransform(svg.node()).k) / 2
-            ]
-          });
-          parentElement.selectAll(".link-block-description").attr('d', link)
-          d3.select(this).attr("transform", "translate(" + d.x + "," + d.y + ")");
+          height_text
+            .filter(d => d.data.data.height == max_height)
+            .style("font-size", "0px")
+            .transition(d3.transition().duration(600))
+            .style("font-size", "10px")
         }
-        function dragended() { d3.select(this).attr("cursor", "drag"); }
-
-        let descCloseGroup = descGroup.append("g")
-
-        let status_text = "";
-        // block description: tip status for nodes
-        if (d.data.data.status != "in-chain") {
-          d.data.data.status.reverse().forEach(status => {
-            status_text += `<span class="text-monospace tip-status-color-fill-${status.status}">▆ </span>`
-            status_text += `<span>${status.count}x ${status.status}: ${status.nodes.map(n => n.name).join(", ")}`
-          })
-        }
-
-
-        function onBlockDescriptionCloseClick(c, d) {
-          let parentElement = d3.select(c.target.parentElement.parentElement.parentElement.parentElement.parentElement.parentElement)
-          parentElement.selectAll(".block-description").remove()
-          parentElement.selectAll(".link-block-description").attr("d", "")
-        }
-
-        let cardWrapper = descGroup.append("foreignObject")
-          .attr("height", "20")
-          .attr("width", "600")
-        let card = cardWrapper
-          .append("xhtml:div")
-            .attr("class", "card m-0 p-0 border")
-        let headerDiv = card.append("xhtml:div").attr("class", "card-header border")
-        headerDiv.append()
-          .html(`<span>Header at height <span style="cursor: pointer" onClick='window.prompt("height:", "${d.data.data.height}")'>${d.data.data.height}</span></span>`)
-        headerDiv.append()
-          .style("float", "right")
-          .html(`<button class="btn btn-close"></button>`)
-          .on("click", (c, d) => onBlockDescriptionCloseClick(c, d));
       
-        card.append("div")
-          .attr("class", "card-body")
-          .html(`
-              <div class="container">
-                <div class="row small">
-                  <div class="col small">
-                    <div class="row" style="cursor: pointer" onClick='window.prompt("hash:", "${d.data.data.hash}")'><span class="col-2">hash</span><span class="col-10 font-monospace small">${d.data.data.hash}</span></div>
-                    <div class="row" style="cursor: pointer" onClick='window.prompt("previous hash:", "${d.data.data.prev_blockhash}")'><span class="col-2">previous</span><span class="col-10 font-monospace small">${d.data.data.prev_blockhash}</span></div>
-                    <div class="row" style="cursor: pointer" onClick='window.prompt("merkle root:", "${d.data.data.merkle_root}")'><span class="col-2">merkleroot</span><span class="col-10 font-monospace small">${d.data.data.merkle_root}</span></div>
-                    <div class="row">
-                      <span class="col-2">timestamp</span><span class="col-4">${d.data.data.time}</span>
-                      <span class="col-2">version</span><span class="col-4 font-monospace">0x${d.data.data.version.toString(16)}</span>
-                      <span class="col-2">nonce</span><span class="col-4 font-monospace">0x${d.data.data.nonce.toString(16)}</span>
-                      <span class="col-2">bits</span><span class="col-4 font-monospace">0x${d.data.data.bits.toString(16)}</span>
-                      ${ d.data.data.miner != "" ? '<span class="col-2">miner</span><span class="col-4 font-monospace">' + d.data.data.miner + '</span>' : '' }
-                    </div>
-                    <div class="row"><span class="col">${status_text}</span></div>
-                  </div>
-                </div>
-              </div>
-          `)
-        cardWrapper.attr("height", card.node().getBoundingClientRect().height / d3.zoomTransform(svg.node()).k )
-        cardWrapper.attr("width", card.node().getBoundingClientRect().width / d3.zoomTransform(svg.node()).k )
+        return newBlocks
+      },
+      update => {
+        update
+          .transition(d3.transition().duration(600))
+          .attr("transform", d => "translate(" + o.x(d, htoi) + "," + o.y(d, htoi) + ")")
+        update.selectAll(".block-pool-name")
+          .attr("transform", `rotate(${o.block_text_rotate},0,0)`)
+        update.selectAll(".node-indicator")
+           .filter(d => d.status == "in-chain")
+           .attr("transform", `rotate(${o.block_text_rotate},0,0)`)
+           .append("text")
+           .text("abcd")
+
+        update.raise()
+        return update
       }
-    }
+    );
 
-  blocks
-    .append('path')
-    .attr("class", "link link-block-description") // when modifying, check if there is a depedency on this class name.
+  let node_groups = g
+    .selectAll(".node-tip-status-indicator")
+    .data(root_node.descendants().filter(d => d.data.data.status != "in-chain" && d.data.data.status != "mining"))
+    .join("g")
+    .classed("node-tip-status-indicator", true)
+    .attr("transform", d => "translate(" + o.x(d, htoi) + "," + o.y(d, htoi) + ")")
 
-  // rect for each block
-  const block_size = 50
-  blocks
-    .append("rect")
-    .attr("height", block_size)
-    .attr("width", block_size)
-    .attr("rx", 5)
-    .attr("fill", "white")
-    .attr("stroke", "black")
-    .attr("stroke-width", "1")
-    .attr("transform", "translate("+ (-block_size)/2  +", " + (-block_size)/2 + ")")
-
-  // height in the block
-  blocks
-    .append("text")
-    .attr("dy", ".35em")
-    .attr("class", "block-text")
-    .text(d => d.data.data.height);
-
-  // miner next to the block
-  blocks
-    .append("text")
-    .attr("transform", `rotate(${o.block_text_rotate},0,0)`)
-    .attr("dy", "4em")
-    .attr("class", "block-miner")
-    .text(d => d.data.data.miner.length > 14 ? d.data.data.miner.substring(0, 14) + "…" : d.data.data.miner);
-
-  var node_groups = blocks
-    .filter(d => d.data.data.status != "in-chain")
-    .append("g")
-    .selectAll("g")
+  let indicators = node_groups.selectAll("g")
     .data(d => d.data.data.status)
     .join("g")
-    .attr("class", d => "node-indicator")
 
-  // node status indicator
-  const indicator_radius = 8
-  const indicator_margin = 1
-  node_groups.append("rect")
+  indicators.append("rect")
     .attr("width", indicator_radius*2)
     .attr("height", indicator_radius*2)
     .attr("rx", 1)
     .attr("r", indicator_radius)
-    .attr("y", -block_size/2 - indicator_radius)
-    .attr("x", (d, i) => (block_size/2) - i * (indicator_radius + indicator_margin) * 2 - indicator_radius)
+    .attr("y", -BLOCK_SIZE/2 - indicator_radius)
+    .attr("x", (d, i) => (BLOCK_SIZE/2) - i * (indicator_radius + indicator_margin) * 2 - indicator_radius)
     .attr("class", d => "tip-status-color-fill-" + d.status)
 
-  node_groups.append("text")
-    .attr("y", -block_size/2)
-    .attr("dx", (d, i) => (block_size/2) - i * (indicator_radius + indicator_margin) * 2)
+  indicators.append("text")
+    .attr("y", -BLOCK_SIZE/2)
+    .attr("dx", (d, i) => (BLOCK_SIZE/2) - i * (indicator_radius + indicator_margin) * 2)
     .attr("dy", ".35em")
-    .attr("class", "node-indicator")
     .text(d => d.count)
 
   let offset_x = 0;
@@ -321,9 +306,14 @@ function draw() {
     offset_y = o.y(max_height_tip, htoi);
   }
 
+  // raise the blocks to make sure they are drawn over the links
+  blocks.raise()
+  node_groups.raise()
+
   zoom.scaleBy(svg, 1);
   let svgSize = d3.select("#drawing-area").node().getBoundingClientRect();
-  zoom.translateTo(svg, offset_x, offset_y, [(svgSize.width)/2, (svgSize.height)/2])
+  zoom.translateTo(svg.transition(d3.transition().duration(initialDraw ? 0 : 750)), offset_x, offset_y, [(svgSize.width)/2, (svgSize.height)/2])
+  initialDraw = false
 }
 
 // recursivly collapses linear branches of blocks longer than x,
@@ -371,6 +361,104 @@ function gen_treemap(o, tips, unique_heights) {
   return d3.tree().size([tips, unique_heights]).nodeSize([NODE_SIZE, NODE_SIZE]);
 }
 
+function onBlockClick(c, d) {
+  let parentElement = d3.select(c.target.parentElement.parentElement)
+  // The on-click listener of the block propagates to the appened description elements.
+  // To prevent adding a second description element of the block we return early if the
+  // parentElement is not the block.
+  if (parentElement.attr("class") == null || !parentElement.attr("class").startsWith("block")) return
+
+  if (parentElement.selectAll(".block-description").size() > 0) {
+    parentElement.selectAll(".block-description").remove()
+    parentElement.selectAll(".link-block-description").attr("d", "")
+  } else {
+
+    const description_offset = { x: 50, y: -50 }
+    const description_margin = { x: 0, y: 15 }
+    let descGroup = parentElement.append("g")
+      .attr("class", "block-description")
+      .attr("transform", "translate(" + description_offset.x + "," + description_offset.y / 2 + ")")
+      .each(d => { d.x = description_offset.x; d.y = description_offset.y })
+      .call(
+        d3.drag()
+          .on("start", dragstarted)
+          .on("drag", dragged)
+          .on("end", dragended)
+      )
+
+    function dragstarted() {d3.select(this).raise().attr("cursor", "grabbing");}
+    function dragged(event, d) {
+      d.x += event.dx;
+      d.y += event.dy;
+      var link = d3.linkHorizontal()({
+        source: [ 0, 0 ],
+        target: [
+          d.x + (card.node().getBoundingClientRect().width  / d3.zoomTransform(svg.node()).k) / 2,
+          d.y + (card.node().getBoundingClientRect().height / d3.zoomTransform(svg.node()).k) / 2
+        ]
+      });
+      parentElement.selectAll(".link-block-description").attr('d', link)
+      d3.select(this).attr("transform", "translate(" + d.x + "," + d.y + ")");
+    }
+    function dragended() { d3.select(this).attr("cursor", "drag"); }
+
+    let descCloseGroup = descGroup.append("g")
+
+    let status_text = "";
+    // block description: tip status for nodes
+    if (d.data.data.status != "in-chain") {
+      d.data.data.status.reverse().forEach(status => {
+        status_text += `<span class="text-monospace tip-status-color-fill-${status.status}">▆ </span>`
+        status_text += `<span>${status.count}x ${status.status}: ${status.nodes.map(n => n.name).join(", ")}`
+      })
+    }
+
+
+    function onBlockDescriptionCloseClick(c, d) {
+      let parentElement = d3.select(c.target.parentElement.parentElement.parentElement.parentElement.parentElement.parentElement)
+      parentElement.selectAll(".block-description").remove()
+      parentElement.selectAll(".link-block-description").attr("d", "")
+    }
+
+    let cardWrapper = descGroup.append("foreignObject")
+      .attr("height", "20")
+      .attr("width", "600")
+    let card = cardWrapper
+      .append("xhtml:div")
+        .attr("class", "card m-0 p-0 border")
+    let headerDiv = card.append("xhtml:div").attr("class", "card-header border")
+    headerDiv.append()
+      .html(`<span>Header at height <span style="cursor: pointer" onClick='window.prompt("height:", "${d.data.data.height}")'>${d.data.data.height}</span></span>`)
+    headerDiv.append()
+      .style("float", "right")
+      .html(`<button class="btn btn-close"></button>`)
+      .on("click", (c, d) => onBlockDescriptionCloseClick(c, d));
+  
+    card.append("div")
+      .attr("class", "card-body")
+      .html(`
+          <div class="container">
+            <div class="row small">
+              <div class="col small">
+                <div class="row" style="cursor: pointer" onClick='window.prompt("hash:", "${d.data.data.hash}")'><span class="col-2">hash</span><span class="col-10 font-monospace small">${d.data.data.hash}</span></div>
+                <div class="row" style="cursor: pointer" onClick='window.prompt("previous hash:", "${d.data.data.prev_blockhash}")'><span class="col-2">previous</span><span class="col-10 font-monospace small">${d.data.data.prev_blockhash}</span></div>
+                <div class="row" style="cursor: pointer" onClick='window.prompt("merkle root:", "${d.data.data.merkle_root}")'><span class="col-2">merkleroot</span><span class="col-10 font-monospace small">${d.data.data.merkle_root}</span></div>
+                <div class="row">
+                  <span class="col-2">timestamp</span><span class="col-4">${d.data.data.time}</span>
+                  <span class="col-2">version</span><span class="col-4 font-monospace">0x${d.data.data.version.toString(16)}</span>
+                  <span class="col-2">nonce</span><span class="col-4 font-monospace">0x${d.data.data.nonce.toString(16)}</span>
+                  <span class="col-2">bits</span><span class="col-4 font-monospace">0x${d.data.data.bits.toString(16)}</span>
+                  ${ d.data.data.miner != "" ? '<span class="col-2">miner</span><span class="col-4 font-monospace">' + d.data.data.miner + '</span>' : '' }
+                </div>
+                <div class="row"><span class="col">${status_text}</span></div>
+              </div>
+            </div>
+          </div>
+      `)
+    cardWrapper.attr("height", card.node().getBoundingClientRect().height / d3.zoomTransform(svg.node()).k )
+    cardWrapper.attr("width", card.node().getBoundingClientRect().width / d3.zoomTransform(svg.node()).k )
+  }
+}
 
 // If nessecary, return a <details> <summary> of the description
 function node_description_summary(description) {

--- a/www/js/blocktree.js
+++ b/www/js/blocktree.js
@@ -30,8 +30,7 @@ const status_to_color = {
   "headers-only": "yellow",
 }
 
-function draw() {
-  data = state_data
+function preprocess_data(data) {  
   let header_infos = data.header_infos;
   let tip_infos = [];
   let node_infos = data.nodes;
@@ -92,7 +91,15 @@ function draw() {
 
   // assigns the data to a hierarchy using parent-child relationships
   // and maps the node data to the tree layout
-  var root_node = treemap(d3.hierarchy(treeData));
+  const root_node = treemap(d3.hierarchy(treeData));
+  const max_height = Math.max(...header_infos.map(d => d.height))
+
+  return [root_node, max_height, htoi]
+}
+
+function draw() {
+  let data = state_data
+  const [root_node, max_height, htoi] = preprocess_data(data)
 
   var svg = d3
     .select("#drawing-area")
@@ -308,7 +315,6 @@ function draw() {
 
   let offset_x = 0;
   let offset_y = 0;
-  let max_height = Math.max(...header_infos.map(d => d.height))
   let max_height_tip = root_node.leaves().filter(d => d.data.data.height == max_height)[0]
   if (max_height_tip !== undefined) {
     offset_x = o.x(max_height_tip, htoi);


### PR DESCRIPTION
Instead of redrawing everything, the front-end now properly [joins](https://d3js.org/d3-selection/joining) the data to the SVG elements and only updates changed/new/removed blocks and links. This also allows showing animations for e.g. new blocks and links.

Showcase:

https://github.com/0xB10C/fork-observer/assets/19157360/d6de5db2-73ef-4149-81a0-a117c75da9b7

