### PR TITLE
improve handling of long node descriptions

### DIFF
--- a/www/js/blocktree.js
+++ b/www/js/blocktree.js
@@ -460,19 +460,12 @@ function onBlockClick(c, d) {
   }
 }
 
-// If nessecary, return a <details> <summary> of the description
-function node_description_summary(description) {
-  if (description.length > 20) {
-    return `
-      <details>
-        <summary>
-          <span>description</span>
-        </summary>
-        <span>${description}</span>
-      </details>
-    `
-  }
-  return description
+function node_description(description) {
+  return `
+    <p class="mb-0 text-truncate" onclick="this.style.whiteSpace = 'normal'">
+      <span>${description}</span>
+    </p>   
+  `
 }
 
 function get_active_height_or_0(node) {
@@ -543,7 +536,7 @@ async function draw_nodes() {
         </div>
         
         <div class="px-2">
-          ${node_description_summary(d.description)}
+          ${node_description(d.description)}
         </div>
         <div class="px-2">
           <span class="small">tip changed <span class="relativeTimestamp" data-timestamp=${d.last_changed_timestamp}>${ago(d.last_changed_timestamp)}</span>


### PR DESCRIPTION
Previously, node descriptions were capped at 20 chars before they would be hidden and rendered as an HTML details-summary element.

This had a few UX problems:
- users need to figure out that they can click on "description"
- users need to actually click on "description"
- https://github.com/bitcoin-dev-project/warnet/issues/656#issuecomment-2416906729
- https://github.com/bitcoin-dev-project/warnet/issues/656#issuecomment-2417351164

To improve this, long node descriptions are now trucated once they would wrap. Upon clicking on them, they are expanded. Now, a user sees the start of the node description (as opposed to only seeing "description") while the node box sizes still are the same on initial page load.

![warnet](https://github.com/user-attachments/assets/98b39b9a-2dc6-451c-96f1-b5bf1ed79975)

