### PR TITLE
add: notify frontend on all cache changes

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -36,7 +36,7 @@ pub fn data_changed_sse(
     network_id: u32,
 ) -> Result<Event, bitcoincore_rpc::jsonrpc::serde_json::Error> {
     warp::sse::Event::default()
-        .event("tip_changed")
+        .event("cache_changed")
         .json_data(DataChanged { network_id })
 }
 


### PR DESCRIPTION
This allows us to react more timely to cache changes. Otherwise, it frequently happend that we displayed a node as lagging behind for a while until we fetched data for the next block. We queue very frequent data fetches up on the frontend, but frequently hitting the backend shouldn't be a problem, as the backend caches the responses.