### PR TITLE
fix: sort chaintips before comparing them

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,7 @@ async fn main() -> Result<(), MainError> {
                     // are using 'continue' on errors. If we would wait at the end,
                     // we might skip the waiting.
                     interval.tick().await;
-                    let tips = match node.tips().await {
+                    let mut tips = match node.tips().await {
                         Ok(tips) => {
                             if !is_node_reachable(&caches_clone, network.id, node.info().id).await {
                                 update_cache(
@@ -228,6 +228,11 @@ async fn main() -> Result<(), MainError> {
                             continue;
                         }
                     };
+
+                    // For example, btcd doesn't gurantee the order of the chain
+                    // tips returned. This means, while they are equal, the order
+                    // can differ and we will treat them as unequal.
+                    tips.sort();
 
                     if last_tips != tips {
                         let (new_headers, miners_needed): (Vec<HeaderInfo>, Vec<BlockHash>) =

--- a/src/types.rs
+++ b/src/types.rs
@@ -207,7 +207,7 @@ pub struct DataChanged {
     pub network_id: u32,
 }
 
-#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ChainTipStatus {
     #[serde(rename = "active")]
     Active,
@@ -260,7 +260,7 @@ impl fmt::Display for ChainTipStatus {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ChainTip {
     pub height: u64,
     pub hash: String,


### PR DESCRIPTION
btcd would return the same chaintips in a different order, which caused us to think they aren't the same as the previous. Sort them to be sure they can be compared.