### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:alpine3.18 as builder
+FROM rust:1-alpine AS builder
 
 WORKDIR /app
 RUN apk add musl-dev
@@ -15,4 +15,4 @@ WORKDIR /app
 COPY --from=builder /usr/local/cargo/bin/fork-observer /usr/local/bin/
 COPY --from=builder /app/www ./www/
 
-CMD /usr/local/bin/fork-observer
+CMD ["/usr/local/bin/fork-observer"]


### PR DESCRIPTION
1. Use `1-alpine` to fix docker build error
2. Use upper "AS" in FROM and array in CMD, to fix docker build warnings

![CleanShot-20250706014256](https://github.com/user-attachments/assets/e437983c-af62-4e3b-a0e9-2982a3a5a20a)
