### PR TITLE
dependabot: ignore semver-patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     open-pull-requests-limit: 10
     allow:
       - dependency-type: "direct"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"


### PR DESCRIPTION
These are too noisy. We only really care about:
- version-update:semver-minor
- version-update:semver-major