### PR TITLE
change: bitcoincore-rpc -> corepc-cilent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -177,6 +177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea507acc1cd80fc084ace38544bbcf7ced7c2aa65b653b102de0ce718df668f6"
 dependencies = [
  "base58ck",
+ "base64 0.21.7",
  "bech32",
  "bitcoin-internals",
  "bitcoin-io",
@@ -236,34 +237,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoincore-rpc"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedd23ae0fd321affb4bbbc36126c6f49a32818dc6b979395d24da8c9d4e80ee"
-dependencies = [
- "bitcoincore-rpc-json",
- "jsonrpc",
- "log",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "bitcoincore-rpc-json"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
-dependencies = [
- "bitcoin",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bitreq"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65c2e1ab98050c93cc9ada070d5070e014329c65196d03f6f8f1f75c2666f37"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "block-buffer"
@@ -343,6 +330,31 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "corepc-client"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349238a237f42ae84050dc449406a734a752c418b9dd531ecb4e93e7b97d094e"
+dependencies = [
+ "bitcoin",
+ "corepc-types",
+ "jsonrpc",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "corepc-types"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86c274042a89391a324ab313b5210680969d02a9fa977733c3354aea4d7a4883"
+dependencies = [
+ "bitcoin",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -484,7 +496,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bitcoin-pool-identification",
- "bitcoincore-rpc",
+ "corepc-client",
  "electrum-client",
  "env_logger",
  "futures-util",
@@ -852,12 +864,12 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3662a38d341d77efecb73caf01420cfa5aa63c0253fd7bc05289ef9f6616e1bf"
+checksum = "f106cca655869522988b976127096f0aa36e0f1a8ff1f1f425a5c85b61e59391"
 dependencies = [
- "base64 0.13.1",
- "minreq",
+ "base64 0.22.1",
+ "bitreq",
  "serde",
  "serde_json",
 ]
@@ -1046,12 +1058,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
 name = "prettyplease"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,36 +1090,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.12",
-]
 
 [[package]]
 name = "regex"
@@ -1295,7 +1271,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes",
- "rand",
  "secp256k1-sys",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-
-bitcoincore-rpc = "0.19.0"
 warp = { version = "0.4.2", features = ["server"] }
 toml = "1.1"
 
@@ -29,6 +27,7 @@ base64 = "0.22.1"
 async-trait = "0.1.89"
 bitcoin-pool-identification = "0.3.7"
 electrum-client = "0.24.0"
+corepc-client = { version = "0.16.0", features = ["client-sync"] }
 
 [features]
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -32,9 +32,7 @@ pub async fn networks_response(
     }))
 }
 
-pub fn data_changed_sse(
-    network_id: u32,
-) -> Result<Event, bitcoincore_rpc::jsonrpc::serde_json::Error> {
+pub fn data_changed_sse(network_id: u32) -> Result<Event, serde_json::Error> {
     warp::sse::Event::default()
         .event("cache_changed")
         .json_data(DataChanged { network_id })

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use crate::error::ConfigError;
 use crate::node::{BitcoinCoreNode, BtcdNode, Electrum, Esplora, Node, NodeInfo};
-use bitcoincore_rpc::bitcoin::Network as BitcoinNetwork;
-use bitcoincore_rpc::Auth;
+use corepc_client::bitcoin::Network as BitcoinNetwork;
+use corepc_client::client_sync::Auth;
 use log::{error, info};
 use serde::Deserialize;
 use std::hash::Hash;

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,8 +3,7 @@ use std::collections::HashMap;
 use petgraph::graph::DiGraph;
 use petgraph::graph::NodeIndex;
 
-use bitcoincore_rpc::bitcoin;
-use bitcoincore_rpc::bitcoin::BlockHash;
+use corepc_client::bitcoin::BlockHash;
 
 use log::{debug, info, warn};
 
@@ -69,7 +68,7 @@ pub async fn write_to_db(
                 &info.height.to_string(),
                 &network.to_string(),
                 &info.header.block_hash().to_string(),
-                &bitcoin::consensus::encode::serialize_hex(&info.header),
+                &corepc_client::bitcoin::consensus::encode::serialize_hex(&info.header),
                 &info.miner,
             ],
         )?;
@@ -148,7 +147,7 @@ async fn load_header_infos(db: Db, network: u32) -> Result<Vec<HeaderInfo>, DbEr
     while let Some(row) = rows.next()? {
         let header_hex: String = row.get(1)?;
         let header_bytes = hex::decode(&header_hex)?;
-        let header = bitcoin::consensus::deserialize(&header_bytes)?;
+        let header = corepc_client::bitcoin::consensus::deserialize(&header_bytes)?;
         headers.push(HeaderInfo {
             height: row.get::<_, i64>(0)? as u64,
             header,

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,13 +2,12 @@ use std::fmt;
 use std::net::AddrParseError;
 use std::{error, io};
 
-use bitcoincore_rpc::bitcoin;
-use bitcoincore_rpc::bitcoin::hashes::hex::parse::HexToArrayError;
+use corepc_client::bitcoin::hashes::hex::parse::HexToArrayError;
 
 #[derive(Debug)]
 pub enum FetchError {
     TokioJoin(tokio::task::JoinError),
-    BitcoinCoreRPC(bitcoincore_rpc::Error),
+    BitcoinCoreRPC(corepc_client::client_sync::Error),
     BitcoinCoreREST(String),
     BtcdRPC(JsonRPCError),
     EsploraREST(EsploraRESTError),
@@ -59,8 +58,8 @@ impl From<tokio::task::JoinError> for FetchError {
     }
 }
 
-impl From<bitcoincore_rpc::Error> for FetchError {
-    fn from(e: bitcoincore_rpc::Error) -> Self {
+impl From<corepc_client::client_sync::Error> for FetchError {
+    fn from(e: corepc_client::client_sync::Error) -> Self {
         FetchError::BitcoinCoreRPC(e)
     }
 }
@@ -75,7 +74,7 @@ impl From<electrum_client::Error> for FetchError {
 pub enum DbError {
     Rusqlite(rusqlite::Error),
     DecodeHex(hex::FromHexError),
-    BitcoinDeserialize(bitcoin::consensus::encode::Error),
+    BitcoinDeserialize(corepc_client::bitcoin::consensus::encode::Error),
 }
 
 impl fmt::Display for DbError {
@@ -110,8 +109,8 @@ impl From<hex::FromHexError> for DbError {
     }
 }
 
-impl From<bitcoin::consensus::encode::Error> for DbError {
-    fn from(e: bitcoin::consensus::encode::Error) -> Self {
+impl From<corepc_client::bitcoin::consensus::encode::Error> for DbError {
+    fn from(e: corepc_client::bitcoin::consensus::encode::Error) -> Self {
         DbError::BitcoinDeserialize(e)
     }
 }
@@ -259,7 +258,7 @@ pub enum JsonRPCError {
     MinReq(minreq::Error),
     FromHex(hex::FromHexError),
     BitcoinFromHex(HexToArrayError),
-    BitcoinDeserializeError(bitcoin::consensus::encode::Error),
+    BitcoinDeserializeError(corepc_client::bitcoin::consensus::encode::Error),
     NotImplemented,
 }
 
@@ -309,8 +308,8 @@ impl From<hex::FromHexError> for JsonRPCError {
     }
 }
 
-impl From<bitcoin::consensus::encode::Error> for JsonRPCError {
-    fn from(e: bitcoin::consensus::encode::Error) -> Self {
+impl From<corepc_client::bitcoin::consensus::encode::Error> for JsonRPCError {
+    fn from(e: corepc_client::bitcoin::consensus::encode::Error) -> Self {
         JsonRPCError::BitcoinDeserializeError(e)
     }
 }

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -4,9 +4,8 @@ use std::str::FromStr;
 use crate::error::JsonRPCError;
 use crate::types::ChainTip;
 
-use bitcoincore_rpc::bitcoin;
-use bitcoincore_rpc::bitcoin::blockdata::block::Header;
-use bitcoincore_rpc::bitcoin::Block;
+use corepc_client::bitcoin::blockdata::block::Header;
+use corepc_client::bitcoin::Block;
 
 use base64::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -126,7 +125,7 @@ pub fn btcd_blockheader(
 
     let header_bytes = hex::decode(header_hex)?;
 
-    let header: Header = bitcoin::consensus::deserialize(&header_bytes)?;
+    let header: Header = corepc_client::bitcoin::consensus::deserialize(&header_bytes)?;
     return Ok(header);
 }
 
@@ -153,7 +152,7 @@ pub fn btcd_block(
 
     let block_hex = jsonrpc_response.result.unwrap_or_default();
     let block_bytes = hex::decode(block_hex)?;
-    let block: Block = bitcoin::consensus::deserialize(&block_bytes)?;
+    let block: Block = corepc_client::bitcoin::consensus::deserialize(&block_bytes)?;
     Ok(block)
 }
 
@@ -162,7 +161,7 @@ pub fn btcd_blockhash(
     user: String,
     password: String,
     height: u64,
-) -> Result<bitcoin::BlockHash, JsonRPCError> {
+) -> Result<corepc_client::bitcoin::BlockHash, JsonRPCError> {
     const METHOD: &str = "getblockhash";
 
     let res = request(
@@ -186,7 +185,7 @@ pub fn btcd_blockhash(
         )));
     }
 
-    Ok(bitcoin::BlockHash::from_str(&hash_hex)?)
+    Ok(corepc_client::bitcoin::BlockHash::from_str(&hash_hex)?)
 }
 
 fn request(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
 
 use bitcoin_pool_identification::{default_data, PoolIdentification};
-use bitcoincore_rpc::bitcoin::{BlockHash, Network};
-use bitcoincore_rpc::Error::JsonRpc;
+use corepc_client::bitcoin::{BlockHash, Network};
+use corepc_client::client_sync::Error::JsonRpc;
 use env_logger::Env;
 use futures_util::StreamExt;
 use log::{debug, error, info, warn};

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,13 +1,11 @@
 use crate::error::{EsploraRESTError, FetchError, JsonRPCError};
 use crate::types::{ChainTip, ChainTipStatus, HeaderInfo, Tree};
 use async_trait::async_trait;
-use bitcoincore_rpc::bitcoin;
-use bitcoincore_rpc::bitcoin::blockdata::block::Header;
-use bitcoincore_rpc::bitcoin::hex::FromHex;
-use bitcoincore_rpc::bitcoin::{BlockHash, Transaction};
-use bitcoincore_rpc::Auth;
-use bitcoincore_rpc::Client;
-use bitcoincore_rpc::RpcApi;
+use corepc_client::bitcoin::blockdata::block::Header;
+use corepc_client::bitcoin::hex::FromHex;
+use corepc_client::bitcoin::{BlockHash, Transaction};
+use corepc_client::client_sync::v31::Client;
+use corepc_client::client_sync::Auth;
 use electrum_client::{
     Client as ElectrumClient, ConfigBuilder as ElectrumClientConfigBuilder, ElectrumApi,
 };
@@ -275,7 +273,7 @@ impl BitcoinCoreNode {
     }
 
     fn rpc_client(&self) -> Result<Client, FetchError> {
-        match Client::new(&self.rpc_url, self.rpc_auth.clone()) {
+        match Client::new_with_auth(&self.rpc_url, self.rpc_auth.clone()) {
             Ok(c) => Ok(c),
             Err(e) => {
                 error!(
@@ -308,36 +306,39 @@ impl Node for BitcoinCoreNode {
 
     async fn version(&self) -> Result<String, FetchError> {
         let rpc = self.rpc_client()?;
-        match task::spawn_blocking(move || rpc.get_network_info()).await {
-            Ok(result) => match result {
-                Ok(result) => Ok(result.subversion),
-                Err(e) => Err(e.into()),
-            },
-            Err(e) => Err(e.into()),
-        }
+        task::spawn_blocking(move || -> Result<String, FetchError> {
+            Ok(rpc
+                .get_network_info()?
+                .into_model()
+                .map_err(|e| FetchError::DataError(e.to_string()))?
+                .subversion)
+        })
+        .await?
     }
 
     async fn block_hash(&self, height: u64) -> Result<BlockHash, FetchError> {
         let rpc = self.rpc_client()?;
-        match task::spawn_blocking(move || rpc.get_block_hash(height)).await {
-            Ok(result) => match result {
-                Ok(result) => Ok(result),
-                Err(e) => Err(e.into()),
-            },
-            Err(e) => Err(e.into()),
-        }
+        task::spawn_blocking(move || -> Result<BlockHash, FetchError> {
+            Ok(rpc
+                .get_block_hash(height)?
+                .into_model()
+                .map_err(|e| FetchError::DataError(e.to_string()))?
+                .0)
+        })
+        .await?
     }
 
     async fn block_header_hash(&self, hash: &BlockHash) -> Result<Header, FetchError> {
         let rpc = self.rpc_client()?;
         let hash_clone = hash.clone();
-        match task::spawn_blocking(move || rpc.get_block_header(&hash_clone)).await {
-            Ok(result) => match result {
-                Ok(result) => Ok(result),
-                Err(e) => Err(e.into()),
-            },
-            Err(e) => Err(e.into()),
-        }
+        task::spawn_blocking(move || -> Result<Header, FetchError> {
+            Ok(rpc
+                .get_block_header(&hash_clone)?
+                .into_model()
+                .map_err(|e| FetchError::DataError(e.to_string()))?
+                .0)
+        })
+        .await?
     }
 
     async fn block_header_height(&self, _: u64) -> Result<Header, FetchError> {
@@ -350,7 +351,7 @@ impl Node for BitcoinCoreNode {
     async fn coinbase(&self, hash: &BlockHash, _height: u64) -> Result<Transaction, FetchError> {
         let rpc = self.rpc_client()?;
         let hash_clone = hash.clone();
-        match task::spawn_blocking(move || rpc.get_block(&hash_clone)).await {
+        match task::spawn_blocking(move || rpc.get_block(hash_clone)).await {
             Ok(result) => match result {
                 Ok(result) => Ok(result
                     .txdata
@@ -365,13 +366,17 @@ impl Node for BitcoinCoreNode {
 
     async fn tips(&self) -> Result<Vec<ChainTip>, FetchError> {
         let rpc = self.rpc_client()?;
-        match task::spawn_blocking(move || rpc.get_chain_tips()).await {
-            Ok(tips_result) => match tips_result {
-                Ok(tips) => Ok(tips.iter().map(|t| t.clone().into()).collect()),
-                Err(e) => Err(e.into()),
-            },
-            Err(e) => Err(e.into()),
-        }
+        task::spawn_blocking(move || -> Result<Vec<ChainTip>, FetchError> {
+            Ok(rpc
+                .get_chain_tips()?
+                .into_model()
+                .map_err(|e| FetchError::DataError(e.to_string()))?
+                .0
+                .into_iter()
+                .map(|t| t.into())
+                .collect())
+        })
+        .await?
     }
 
     async fn batch_header_fetch(
@@ -404,14 +409,11 @@ impl Node for BitcoinCoreNode {
             )));
         }
 
-        let header_results: Result<
-            Vec<Header>,
-            bitcoincore_rpc::bitcoin::consensus::encode::Error,
-        > = res
-            .as_bytes()
-            .chunks(80)
-            .map(bitcoin::consensus::deserialize::<Header>)
-            .collect();
+        let header_results: Result<Vec<Header>, corepc_client::bitcoin::consensus::encode::Error> =
+            res.as_bytes()
+                .chunks(80)
+                .map(corepc_client::bitcoin::consensus::deserialize::<Header>)
+                .collect();
 
         let headers = match header_results {
             Ok(headers) => headers,
@@ -591,13 +593,15 @@ impl Node for Esplora {
             200 => {
                 let header_str = res.as_str()?;
                 match Vec::from_hex(header_str) {
-                    Ok(header_bytes) => match bitcoin::consensus::deserialize(&header_bytes) {
-                        Ok(header) => Ok(header),
-                        Err(e) => Err(FetchError::DataError(format!(
-                            "Can't deserialize block header '{}': {}",
-                            header_str, e
-                        ))),
-                    },
+                    Ok(header_bytes) => {
+                        match corepc_client::bitcoin::consensus::deserialize(&header_bytes) {
+                            Ok(header) => Ok(header),
+                            Err(e) => Err(FetchError::DataError(format!(
+                                "Can't deserialize block header '{}': {}",
+                                header_str, e
+                            ))),
+                        }
+                    }
                     Err(e) => Err(FetchError::DataError(format!(
                         "Can't hex decode block header '{}': {}",
                         header_str, e
@@ -643,7 +647,7 @@ impl Node for Esplora {
                 match res.status_code {
                     200 => match Vec::from_hex(coinbase_hex) {
                         Ok(coinbase_bytes) => {
-                            match bitcoin::consensus::deserialize(&coinbase_bytes) {
+                            match corepc_client::bitcoin::consensus::deserialize(&coinbase_bytes) {
                                 Ok(tx) => Ok(tx),
                                 Err(e) => Err(FetchError::DataError(format!(
                                     "Can't deserialize coinbase transaction '{}': {}",

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,9 +7,9 @@ use std::time::SystemTime;
 use crate::config::Network;
 use crate::node::NodeInfo;
 
-use bitcoincore_rpc::bitcoin::blockdata::block::Header;
-use bitcoincore_rpc::bitcoin::BlockHash;
-use bitcoincore_rpc::json::{GetChainTipsResultStatus, GetChainTipsResultTip};
+use corepc_client::bitcoin::blockdata::block::Header;
+use corepc_client::bitcoin::BlockHash;
+use corepc_client::types::model::{ChainTips, ChainTipsStatus};
 use log::warn;
 use petgraph::graph::DiGraph;
 use petgraph::graph::NodeIndex;
@@ -235,14 +235,14 @@ impl From<String> for ChainTipStatus {
     }
 }
 
-impl From<GetChainTipsResultStatus> for ChainTipStatus {
-    fn from(s: GetChainTipsResultStatus) -> Self {
+impl From<ChainTipsStatus> for ChainTipStatus {
+    fn from(s: ChainTipsStatus) -> Self {
         match s {
-            GetChainTipsResultStatus::Active => ChainTipStatus::Active,
-            GetChainTipsResultStatus::Invalid => ChainTipStatus::Invalid,
-            GetChainTipsResultStatus::HeadersOnly => ChainTipStatus::HeadersOnly,
-            GetChainTipsResultStatus::ValidHeaders => ChainTipStatus::ValidHeaders,
-            GetChainTipsResultStatus::ValidFork => ChainTipStatus::ValidFork,
+            ChainTipsStatus::Active => ChainTipStatus::Active,
+            ChainTipsStatus::Invalid => ChainTipStatus::Invalid,
+            ChainTipsStatus::HeadersOnly => ChainTipStatus::HeadersOnly,
+            ChainTipsStatus::ValidHeaders => ChainTipStatus::ValidHeaders,
+            ChainTipsStatus::ValidFork => ChainTipStatus::ValidFork,
         }
     }
 }
@@ -268,12 +268,12 @@ pub struct ChainTip {
     pub status: ChainTipStatus,
 }
 
-impl From<GetChainTipsResultTip> for ChainTip {
-    fn from(t: GetChainTipsResultTip) -> Self {
+impl From<ChainTips> for ChainTip {
+    fn from(t: ChainTips) -> Self {
         ChainTip {
-            height: t.height,
+            height: t.height as u64,
             hash: t.hash.to_string(),
-            branchlen: t.branch_length,
+            branchlen: t.branch_length as usize,
             status: t.status.into(),
         }
     }


### PR DESCRIPTION
The bitcoincore-rpc crate is largely unmaintained. The corepc crate is maintained and supports up-to-date Bitcoin Core versions.