### PR TITLE
add: use waitfornewblock on Bitcoin Core nodes

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -6,7 +6,13 @@ database_path = "example_db_dir"
 # path to the location of the static www files
 www_path = "./www"
 
-# Interval in seconds for checking for new blocks
+# Interval in seconds for checking for new blocks.
+#
+# For Bitcoin Core nodes (unless `use_waitfornewblock = false` is set on the
+# node) this is the *maximum* time between checks: the node reacts to new blocks
+# almost immediately via the `waitfornewblock` RPC long-poll and only falls back
+# to this interval as an upper bound. For all other backends this is the fixed
+# polling interval.
 query_interval = 15
 
 # Webserver listen address
@@ -50,6 +56,11 @@ max_interesting_heights = 100
     rpc_port = 38342
     rpc_user = "forkobserver"
     rpc_password = ""
+    # React to new blocks via Bitcoin Core's `waitfornewblock` RPC long-poll
+    # instead of polling every `query_interval` seconds. Defaults to true. Set
+    # to false if `waitfornewblock` is not on the RPC whitelist, or if a reverse
+    # proxy in front of the node kills long-held connections.
+    # use_waitfornewblock = true
 
     [[networks.nodes]]
     id = 1

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ pub const ENVVAR_CONFIG_FILE: &str = "CONFIG_FILE";
 const DEFAULT_CONFIG: &str = "config.toml";
 const DEFAULT_BACKEND: Backend = Backend::BitcoinCore;
 const DEFAULT_USE_REST: bool = true;
+const DEFAULT_USE_WAITFORNEWBLOCK: bool = true;
 const DEFAULT_RPC_PORT: u16 = 8332;
 
 pub type BoxedSyncSendNode = Arc<dyn Node + Send + Sync>;
@@ -114,13 +115,14 @@ struct TomlNode {
     rpc_user: Option<String>,
     rpc_password: Option<String>,
     use_rest: Option<bool>,
+    use_waitfornewblock: Option<bool>,
     implementation: Option<String>,
 }
 
 impl fmt::Display for TomlNode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
-            f,"Node (id={}, description='{}', name='{}', rpc_host='{}', rpc_port={}, rpc_user='{}', rpc_password='***', rpc_cookie_file={:?}, use_rest={}, implementation='{}')",
+            f,"Node (id={}, description='{}', name='{}', rpc_host='{}', rpc_port={}, rpc_user='{}', rpc_password='***', rpc_cookie_file={:?}, use_rest={}, use_waitfornewblock={}, implementation='{}')",
             self.id,
             self.description,
             self.name,
@@ -129,6 +131,7 @@ impl fmt::Display for TomlNode {
             self.rpc_user.as_ref().unwrap_or(&"".to_string()),
             self.rpc_cookie_file,
             self.use_rest.unwrap_or(DEFAULT_USE_REST),
+            self.use_waitfornewblock.unwrap_or(DEFAULT_USE_WAITFORNEWBLOCK),
             self.implementation.as_ref().unwrap_or(&"".to_string()),
         )
     }
@@ -302,6 +305,9 @@ fn parse_toml_node(toml_node: &TomlNode) -> Result<BoxedSyncSendNode, ConfigErro
             ),
             parse_rpc_auth(toml_node)?,
             toml_node.use_rest.unwrap_or(DEFAULT_USE_REST),
+            toml_node
+                .use_waitfornewblock
+                .unwrap_or(DEFAULT_USE_WAITFORNEWBLOCK),
         )),
         Backend::Btcd => {
             if toml_node.rpc_user.is_none() || toml_node.rpc_password.is_none() {
@@ -355,6 +361,39 @@ mod tests {
         assert_eq!(cfg.networks.len(), 2);
         assert_eq!(cfg.query_interval, std::time::Duration::from_secs(15));
         assert_eq!(cfg.networks[0].pool_identification.enable, true);
+    }
+
+    #[test]
+    fn use_waitfornewblock_parsing() {
+        // Defaults to None (=> DEFAULT_USE_WAITFORNEWBLOCK = true) when omitted.
+        let node: TomlNode = toml::from_str(
+            r#"
+            id = 0
+            name = "n"
+            description = ""
+            rpc_host = "127.0.0.1"
+            "#,
+        )
+        .expect("node without use_waitfornewblock should parse");
+        assert_eq!(node.use_waitfornewblock, None);
+        assert_eq!(
+            node.use_waitfornewblock
+                .unwrap_or(DEFAULT_USE_WAITFORNEWBLOCK),
+            true
+        );
+
+        // Honors an explicit `false`.
+        let node: TomlNode = toml::from_str(
+            r#"
+            id = 0
+            name = "n"
+            description = ""
+            rpc_host = "127.0.0.1"
+            use_waitfornewblock = false
+            "#,
+        )
+        .expect("node with use_waitfornewblock should parse");
+        assert_eq!(node.use_waitfornewblock, Some(false));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc::unbounded_channel;
 use tokio::sync::{broadcast, Mutex};
 use tokio::task;
-use tokio::time::{interval, interval_at, sleep, Duration, Instant};
+use tokio::time::{interval, sleep, Duration};
 use tokio_stream::wrappers::BroadcastStream;
 use warp::Filter;
 
@@ -155,15 +155,13 @@ async fn main() -> Result<(), MainError> {
 
         for node in network.nodes.iter().cloned() {
             let network = network.clone();
-            // Spread query times equally apart to even out network/CPU load
-            let mut interval = interval_at(
-                Instant::now()
-                    + Duration::from_millis(
-                        (config.query_interval.as_millis() / network.nodes.len() as u128) as u64,
-                    )
-                    + Duration::from_secs((network.id % 10) as u64),
-                config.query_interval,
-            );
+            let query_interval = config.query_interval;
+            // Spread the initial query times apart to even out network/CPU load
+            // on startup. Afterwards each node waits for its own tip changes (via
+            // `wait_for_tip_change`), so the load naturally spreads out.
+            let initial_stagger = Duration::from_millis(
+                (query_interval.as_millis() / network.nodes.len() as u128) as u64,
+            ) + Duration::from_secs((network.id % 10) as u64);
             let db_write = db.clone();
             let tree_clone = tree.clone();
             let caches_clone = caches.clone();
@@ -184,11 +182,29 @@ async fn main() -> Result<(), MainError> {
                 )
                 .await;
 
+                let mut first_iteration = true;
                 loop {
                     // We specifically wait at the beginning of the loop, as we
                     // are using 'continue' on errors. If we would wait at the end,
                     // we might skip the waiting.
-                    interval.tick().await;
+                    if first_iteration {
+                        // Fetch immediately on startup (after a small stagger) so
+                        // we catch up on headers we missed while we were down.
+                        sleep(initial_stagger).await;
+                        first_iteration = false;
+                    } else if let Err(e) = node.wait_for_tip_change(query_interval).await {
+                        // `wait_for_tip_change` failed (e.g. `waitfornewblock` is
+                        // not whitelisted on the node). Fall back to a fixed-delay
+                        // poll so we don't busy-loop.
+                        debug!(
+                            "wait_for_tip_change failed for {} on network '{}' (id={}): {} - falling back to polling",
+                            node.info(),
+                            network.name,
+                            network.id,
+                            e
+                        );
+                        sleep(query_interval).await;
+                    }
                     let mut tips = match node.tips().await {
                         Ok(tips) => {
                             if !is_node_reachable(&caches_clone, network.id, node.info().id).await {

--- a/src/node.rs
+++ b/src/node.rs
@@ -56,6 +56,18 @@ pub trait Node: Sync {
         count: u64,
     ) -> Result<Vec<Header>, FetchError>;
 
+    /// Blocks until the node's tip likely changed, or until `timeout` elapses,
+    /// whichever comes first. Returning is only a hint to re-fetch tips; callers
+    /// must still call `tips()` and compare. The default implementation simply
+    /// waits out the `timeout` (i.e. preserves the fixed-interval polling
+    /// behaviour). Implementations that support a push/long-poll mechanism (e.g.
+    /// Bitcoin Core's `waitfornewblock`) can override this to return as soon as a
+    /// new block arrives.
+    async fn wait_for_tip_change(&self, timeout: Duration) -> Result<(), FetchError> {
+        tokio::time::sleep(timeout).await;
+        Ok(())
+    }
+
     async fn new_headers(
         &self,
         tips: &Vec<ChainTip>,
@@ -260,15 +272,23 @@ pub struct BitcoinCoreNode {
     rpc_url: String,
     rpc_auth: Auth,
     use_rest: bool,
+    use_waitfornewblock: bool,
 }
 
 impl BitcoinCoreNode {
-    pub fn new(info: NodeInfo, rpc_url: String, rpc_auth: Auth, use_rest: bool) -> Self {
+    pub fn new(
+        info: NodeInfo,
+        rpc_url: String,
+        rpc_auth: Auth,
+        use_rest: bool,
+        use_waitfornewblock: bool,
+    ) -> Self {
         BitcoinCoreNode {
             info,
             rpc_url,
             rpc_auth,
             use_rest,
+            use_waitfornewblock,
         }
     }
 
@@ -375,6 +395,31 @@ impl Node for BitcoinCoreNode {
                 .into_iter()
                 .map(|t| t.into())
                 .collect())
+        })
+        .await?
+    }
+
+    async fn wait_for_tip_change(&self, timeout: Duration) -> Result<(), FetchError> {
+        if !self.use_waitfornewblock {
+            tokio::time::sleep(timeout).await;
+            return Ok(());
+        }
+
+        // The `corepc_client` `Client` has a hardcoded 60s HTTP transport
+        // timeout. We cap the server-side `waitfornewblock` timeout safely below
+        // that: on timeout Bitcoin Core returns the current tip (no error), the
+        // caller sees no tip change and we simply re-issue on the next loop.
+        const MAX_WAIT: Duration = Duration::from_secs(50);
+        let timeout_ms = timeout.min(MAX_WAIT).as_millis() as u64;
+
+        let rpc = self.rpc_client()?;
+        task::spawn_blocking(move || -> Result<(), FetchError> {
+            // `corepc_client`'s `wait_for_new_block()` helper sends no timeout
+            // (i.e. blocks indefinitely), so we issue the raw call with an
+            // explicit timeout in milliseconds instead. We only use the response
+            // as a wake-up signal and re-fetch the tips afterwards.
+            rpc.call::<serde_json::Value>("waitfornewblock", &[timeout_ms.into()])?;
+            Ok(())
         })
         .await?
     }
@@ -965,6 +1010,7 @@ mod bitcoin_core_tests {
             core.rpc_url(),
             Auth::CookieFile(core.params.cookie_file.clone()),
             false, // use_rest
+            true,  // use_waitfornewblock
         )
     }
 
@@ -1090,6 +1136,91 @@ mod bitcoin_core_tests {
         assert_eq!(
             invalid_tip.branchlen, 2,
             "invalid branch (blocks 4 and 5) should have length 2"
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_tip_change_wakes_on_new_block() {
+        let core = start_bitcoind();
+        let address = core.client.new_address().expect("new_address failed");
+        // Mine one block so the node has a non-genesis tip to wait past.
+        core.client
+            .generate_to_address(1, &address)
+            .expect("generate_to_address failed");
+
+        let node = node_under_test(&core);
+
+        // Wait for a tip change with a generous timeout while concurrently mining
+        // a new block. `waitfornewblock` should return well before the timeout.
+        let timeout = Duration::from_secs(30);
+        let start = std::time::Instant::now();
+        let (wait_result, _) = tokio::join!(node.wait_for_tip_change(timeout), async {
+            // Give `wait_for_tip_change` a moment to issue waitfornewblock first.
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            core.client
+                .generate_to_address(1, &address)
+                .expect("generate_to_address failed");
+        });
+
+        wait_result.expect("wait_for_tip_change should not error");
+        assert!(
+            start.elapsed() < timeout,
+            "wait_for_tip_change should return promptly after a new block, not hit the timeout"
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_tip_change_returns_on_timeout() {
+        let core = start_bitcoind();
+        let node = node_under_test(&core);
+
+        // With no new block arriving, `waitfornewblock` returns the current tip
+        // once the timeout elapses - without erroring.
+        let timeout = Duration::from_secs(1);
+        let start = std::time::Instant::now();
+        node.wait_for_tip_change(timeout)
+            .await
+            .expect("wait_for_tip_change should return Ok on timeout");
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= timeout,
+            "should wait out the full timeout, waited {:?}",
+            elapsed
+        );
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "should return shortly after the timeout, waited {:?}",
+            elapsed
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_tip_change_polling_fallback_when_disabled() {
+        // With `use_waitfornewblock = false` the node must not contact the RPC at
+        // all; it simply waits out the timeout. We therefore point it at an unused
+        // address and still expect a clean, timely return (no bitcoind needed).
+        let info = NodeInfo {
+            id: 0,
+            name: "disabled".to_string(),
+            description: String::new(),
+            implementation: "Bitcoin Core".to_string(),
+        };
+        let node = BitcoinCoreNode::new(
+            info,
+            "127.0.0.1:1".to_string(),
+            Auth::UserPass("user".to_string(), "pass".to_string()),
+            false, // use_rest
+            false, // use_waitfornewblock
+        );
+
+        let timeout = Duration::from_millis(200);
+        let start = std::time::Instant::now();
+        node.wait_for_tip_change(timeout)
+            .await
+            .expect("polling fallback should return Ok");
+        assert!(
+            start.elapsed() >= timeout,
+            "polling fallback should wait out the full timeout"
         );
     }
 }


### PR DESCRIPTION
This allows us to react to new blocks a lot faster, where supported.

closes #109