### PR TITLE
change: modernize frontend

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -2,7 +2,14 @@
   color-scheme: light dark;
 
   /* default light mode values */
-  --body-bg: white;
+  --body-bg: #fbfbfc;
+  --surface-bg: #ffffff;
+  --border-soft: rgba(0, 0, 0, 0.18);
+  --muted-soft: rgba(0, 0, 0, 0.55);
+  --block-stroke: rgba(180, 180, 180, 1);
+  --block-top: #e7e9ee;
+  --block-side: #c7ccd5;
+  --accent: gray;
   --text-color: black;
   --block-to-block-link-color: black;
   --block-description-link-color: gray;
@@ -21,7 +28,14 @@
 /* keep the rules in sync with the manual dark mode below! */
 @media (prefers-color-scheme: dark) {
   :root {
-    --body-bg: #202124;
+    --body-bg: #18191c;
+    --surface-bg: #232427;
+    --border-soft: rgba(255, 255, 255, 0.2);
+    --muted-soft: rgba(255, 255, 255, 0.6);
+    --block-stroke: rgba(255, 255, 255, 0.28);
+    --block-top: #34353c;
+    --block-side: #15161a;
+    --accent: #f7931a;
     --text-color: white;
     --block-to-block-link-color: white;
     --block-description-link-color: lightgray;
@@ -44,7 +58,14 @@
 /* manual dark mode */
 /* keep the rules in sync with the automatic dark mode above! */
 :root.dark {
-  --body-bg: #202124;
+  --body-bg: #18191c;
+  --surface-bg: #232427;
+  --border-soft: rgba(255, 255, 255, 0.2);
+  --muted-soft: rgba(255, 255, 255, 0.6);
+  --block-stroke: rgba(255, 255, 255, 0.28);
+  --block-top: #34353c;
+  --block-side: #15161a;
+  --accent: #f7931a;
   --text-color: white;
   --block-to-block-link-color: white;
   --block-description-link-color: lightgray;
@@ -63,16 +84,35 @@
   }
 }
 
-body, .card {
+body {
   background: var(--body-bg);
+  color: var(--text-color);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
 
-h1, h2, h3, h4, h5, h6, p, label, span, hr, a {
+.card {
+  background: var(--surface-bg);
+}
+
+h1, h2, h3, h4, h5, h6, p, label, span, hr, a,
+.h1, .h2, .h3, .h4, .h5, .h6 {
   color: var(--text-color);
 }
 
 .border {
-  border-color: var(--text-color);
+  border-color: var(--border-soft) !important;
+}
+
+.text-muted-soft {
+  color: var(--muted-soft) !important;
+}
+
+/* let native-styled selects adopt the surface colors */
+.form-select {
+  background-color: var(--surface-bg);
+  color: var(--text-color);
+  border-color: var(--border-soft);
+  border-radius: 0;
 }
 
 .text-color-dark {
@@ -86,6 +126,7 @@ h1, h2, h3, h4, h5, h6, p, label, span, hr, a {
 path.link.link-block-block {
   stroke: var(--block-to-block-link-color);
   stroke-width: 2px;
+  stroke-linejoin: round;
 }
 
 path.link.link-block-description {
@@ -99,16 +140,41 @@ text.text-blocks-not-shown {
  font-size: 12px;
 }
 
+rect.block-background {
+ fill: var(--surface-bg);
+}
+
+/* 3D cube faces behind the front square (fill only; edges drawn once by .block-edges) */
+polygon.block-face-top {
+ fill: var(--block-top);
+}
+
+polygon.block-face-side {
+ fill: var(--block-side);
+}
+
+/* the cube's top/side/back edges, drawn once so shared edges don't double up */
+path.block-edges {
+ fill: none;
+ stroke: var(--block-stroke);
+ stroke-width: 1px;
+ stroke-linejoin: round;
+}
+
 text.block-text {
- fill: black;
+ fill: var(--text-color);
  text-anchor: middle;
- font-size: 10px;
+ font-size: 11px;
 }
 
 text.block-miner {
  fill: var(--block-miner-color);
  text-anchor: middle;
  font-size: 10px;
+}
+
+rect.block-miner-bg {
+ fill: var(--surface-bg);
 }
 
 .block {
@@ -124,23 +190,21 @@ text.block-miner {
   stroke: var(--text-color);
 }
 
-.node-tip-status-indicator {
- stroke: var(--node-indicatior-stroke);
- stroke-width: 1px;
-}
-
-.node-tip-status-indicator text {
+/* tip info: stack of colored "Nx status" boxes next to a tip block */
+.tip-info-bg {
+ stroke: var(--block-stroke);
  stroke-width: 0px;
- font-size: 14px;
- text-anchor: middle;
- fill: black;
 }
 
-/* For the legend */ 
+.tip-info-text {
+ fill: #1a1a1a;
+ font-size: 8px;
+ cursor: default;
+}
+
 .legend-item {
   color: black;
-  padding: 2px 5px;
-  border-radius: 5px;
+  padding: 1px 6px;
 }
 
 .tip-status-color-background-active { background-color: var(--tip-status-color-active); }
@@ -178,4 +242,305 @@ text.block-miner {
   100% {
     opacity: 1;
   }
+}
+
+/* ---------------------------------------------------------------------------
+   Modern layout
+   --------------------------------------------------------------------------- */
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+/* compact, sticky top bar */
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  margin-bottom: 1rem;
+  background: color-mix(in srgb, var(--body-bg) 88%, transparent);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.app-header .navbar-brand span {
+  font-size: 1.25rem;
+}
+
+/* toolbar above the visualization: title/description on the left, controls right */
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 0.75rem 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.toolbar-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 1rem;
+}
+
+/* small RSS feed pills */
+.feed-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.feed-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  color: var(--muted-soft);
+  border: 1px solid var(--border-soft);
+  text-decoration: none;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+/* square corners everywhere to match the block theme */
+.badge {
+  border-radius: 0 !important;
+}
+
+.feed-pill:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.feed-pill img {
+  opacity: 0.7;
+}
+
+/* the visualization is the centerpiece: keep it large */
+.viz {
+  display: block;
+  width: 100%;
+  height: 78vh;
+  background: var(--surface-bg);
+}
+
+/* wraps the SVG so the recenter button can float over its corner */
+.viz-wrap {
+  position: relative;
+}
+
+.viz-recenter {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  line-height: 1.2;
+  color: var(--accent);
+  background: var(--surface-bg);
+  border: 1px solid var(--block-stroke);
+  cursor: pointer;
+}
+
+.viz-recenter:hover {
+  border-color: var(--accent);
+}
+
+/* fields in the block info card / table that copy to the clipboard on click */
+.copyable {
+  cursor: pointer;
+}
+
+.copyable:hover {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+/* transient confirmation toast (clipboard copy) */
+.toast-msg {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%) translateY(10px);
+  padding: 8px 16px;
+  font-size: 0.85rem;
+  color: var(--surface-bg);
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  z-index: 1080;
+}
+
+.toast-msg.toast-show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* horizontal scroll keeps the node table usable on narrow screens */
+.node-table-wrap {
+  margin-top: 0.6rem;
+  overflow-x: auto;
+  border: 1px solid var(--border-soft);
+}
+
+@media (max-width: 575.98px) {
+  .toolbar-controls {
+    width: 100%;
+  }
+  .viz {
+    height: 70vh;
+  }
+}
+
+/* node table: one node per row */
+.node-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--surface-bg);
+  font-size: 0.95rem;
+}
+
+.node-table thead th {
+  position: sticky;
+  top: 0;
+  background: var(--surface-bg);
+  text-align: left;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--muted-soft);
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-soft);
+  white-space: nowrap;
+}
+
+.node-table td {
+  padding: 0.5rem 0.75rem;
+  vertical-align: middle;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.node-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.node-row {
+  transition: background-color 0.15s ease;
+}
+
+.node-row:hover {
+  background: color-mix(in srgb, var(--accent) 7%, var(--surface-bg));
+}
+
+.nt-name {
+  min-width: 12rem;
+}
+
+.node-status-dot {
+  display: inline-block;
+  width: 0.55rem;
+  height: 0.55rem;
+  margin-right: 0.4rem;
+  vertical-align: middle;
+}
+
+.node-status-dot.is-up {
+  background: var(--tip-status-color-active);
+}
+
+.node-status-dot.is-down {
+  background: var(--tip-status-color-invalid);
+}
+
+.nt-name-text {
+  font-weight: 600;
+  vertical-align: middle;
+}
+
+.nt-desc {
+  color: var(--muted-soft);
+  font-size: 0.82rem;
+  margin-top: 0.15rem;
+  max-width: 22rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.nt-desc.nt-desc-open {
+  white-space: normal;
+}
+
+.nt-impl {
+  white-space: nowrap;
+}
+
+.nt-time {
+  white-space: nowrap;
+}
+
+.nt-num {
+  text-align: left;
+}
+
+/* solid color chips: same height -> same height-chip color; same tip -> same
+   hash-chip color. hues come from the --height-hue / --hash-hue vars on the row. */
+.height-chip,
+.hash-chip {
+  display: inline-block;
+  padding: 0.12rem 0.5rem;
+  color: #1a1a1a;
+  white-space: nowrap;
+}
+
+.height-chip {
+  background: hsl(var(--height-hue, 0) 68% 74%);
+  font-variant-numeric: tabular-nums;
+}
+
+.hash-chip {
+  background: hsl(var(--hash-hue, 0) 68% 74%);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.hash-chip:hover {
+  filter: brightness(0.95);
+}
+
+/* the open block-header info card in the visualization */
+.block-info-card {
+  border-radius: 0 !important;
+  overflow: hidden;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.28);
+}
+
+.block-info-card .card-header {
+  background: var(--body-bg);
+  font-weight: 600;
+}
+
+/* footer */
+.app-footer {
+  border-top: 1px solid var(--border-soft);
+}
+
+.footer-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--text-color);
+}
+
+.footer-link:hover {
+  color: var(--accent);
 }

--- a/www/index.html
+++ b/www/index.html
@@ -13,91 +13,81 @@
 </head>
 
 <body>
-  <div class="container-fluid" style="display: flex; flex-direction: column; min-height: 100vh;">
-    <header class="border-bottom mb-3">
-      <nav class="navbar">
-        <a class="navbar-brand" href="/">
-          <img src="static/img/logo.svg" width="32" height="32" class="d-inline-block align-top invert" alt="">
-          <span>fork-observer</span>
+  <div class="container-fluid app-shell">
+    <header class="app-header">
+      <nav class="navbar py-2">
+        <a class="navbar-brand d-flex align-items-center gap-2 m-0" href="/">
+          <img src="static/img/logo.svg" width="30" height="30" class="d-inline-block align-top invert" alt="">
+          <span class="fw-semibold">fork-observer</span>
         </a>
-        <div>
-          <label>
-            Network
-            <select name="network" id="network"></select>
+        <div class="d-flex align-items-center gap-3">
+          <label class="d-flex align-items-center gap-2 m-0">
+            <span class="small text-muted-soft">Network</span>
+            <select name="network" id="network" class="form-select form-select-sm"></select>
           </label>
-          <span>|</span>
-          <label>Connection <span id="connection-status" class="small" style="color: gray">⬤</span></label>
+          <label class="d-flex align-items-center gap-1 m-0" title="Connection status">
+            <span class="small text-muted-soft">Connection</span>
+            <span id="connection-status" style="color: gray">█</span>
+          </label>
         </div>
       </nav>
     </header>
-    <main style="flex: 1;">
-      <div style="display: flex; flex-direction: column;">
-        <p>
-          <h3>Network: <span id="network_info_name"></span></h3>
-          <span id="network_info_description"></span>
-          <br>
-          <p class="small">
-            <span>
-              <img src="static/img/rss-feed-white.svg" height=18>
-              <a target="_blank" id="rss_recent_forks">Recent forks</a>
-            </span>
-            <span>
-              <img src="static/img/rss-feed-white.svg" height=18>
-              <a target="_blank" id="rss_invalid_blocks">Invalid blocks</a>
-            </span>
-            <span>
-              <img src="static/img/rss-feed-white.svg" height=18>
-              <a target="_blank" id="rss_lagging_nodes">Lagging nodes</a>
-            </span>
-            <span>
-              <img src="static/img/rss-feed-white.svg" height=18>
-              <a target="_blank" id="rss_unreachable_nodes">Unreachable nodes</a>
-            </span>
-          </p>
-          <br>
-          <details style="color: var(--text-color);" open>
-            <summary>
-              <span class="h4">Nodes</span>
-            </summary>
-            <div class="container-fluid">
-              <div class="row row-cols-auto" id="node_infos"></div>
-            </div>
-          </details>
-        </p>
-        <div>
-          <label>orientation <select name="orientation" id="orientation"></select></label>
+    <main class="flex-grow-1">
+      <div class="toolbar">
+        <div class="toolbar-info">
+          <h1 class="h3 mb-1" id="network_info_name"></h1>
+          <p class="text-muted-soft mb-0" id="network_info_description"></p>
         </div>
-        <svg style="flex:1; flex-basis: 75vh; height:75vh;" class="border" id="drawing-area">
-          <foreignobject id="legend" x="0" y="5" width="150" height="300" style="text-align: right;">
-            <label>tip status</label><br>
-            <span class="tip-status-color-background-active legend-item"><abbr title="This is the tip of the active main chain, which is certainly valid">active</abbr></span><br>
-            <span class="tip-status-color-background-valid-fork legend-item"><abbr title="This branch is not part of the active chain, but is fully validated">valid-fork</abbr></span><br>
-            <span class="tip-status-color-background-valid-headers legend-item"><abbr title="All blocks are available for this branch, but they were never fully validated">valid-headers</abbr></span><br>
-            <span class="tip-status-color-background-headers-only legend-item"><abbr title="Not all blocks for this branch are available, but the headers are valid">headers-only</abbr></span><br>
-            <span class="tip-status-color-background-invalid legend-item"><abbr title="This branch contains at least one invalid block">invalid</abbr></span><br>
-          </foreignobject>
-        </svg>
+        <div class="toolbar-controls">
+          <label class="d-flex align-items-center gap-2 m-0">
+            <span class="small text-muted-soft">orientation</span>
+            <select name="orientation" id="orientation" class="form-select form-select-sm"></select>
+          </label>
+        </div>
       </div>
+      <div class="viz-wrap">
+        <svg class="viz border" id="drawing-area"></svg>
+        <button type="button" class="viz-recenter" id="recenter" title="Recenter on the chain tip" onclick="recenter()">re-center</button>
+      </div>
+      <details class="text-muted">
+        <summary>Tip status legend</summary>
+        <span class="legend-item tip-status-color-background-active">active</span><span class="px-1">This is the tip of the active main chain, which is certainly valid.</span></li>
+        <span class="legend-item tip-status-color-background-valid-fork">valid-fork</span><span class="px-1">This branch is not part of the active chain, but is fully validated.</span></li>
+        <span class="legend-item tip-status-color-background-valid-headers">valid-headers</span><span class="px-1">All blocks are available for this branch, but they were never fully validated.</span></li>
+        <span class="legend-item tip-status-color-background-headers-only">headers-only</span><span class="px-1">Not all blocks for this branch are available, but the headers are valid.</span></li>
+        <span class="legend-item tip-status-color-background-invalid">invalid</span><span class="px-1">This branch contains at least one invalid block.</span>
+      </details>
+      <section class="nodes-section mt-3">
+        <h2 class="h5 mb-2">Nodes</h2>
+        <span>List of nodes attached to this fork-observer instance.</span>
+        <div class="node-table-wrap" id="node_infos"></div>
+      </section>
+      <section class="feeds-section mt-4">
+        <h2 class="h5 mb-2">RSS feeds</h2>
+        <div class="feed-pills">
+          <a target="_blank" class="feed-pill" id="rss_recent_forks"><img src="static/img/rss-feed-white.svg" height=12>Recent forks</a>
+          <a target="_blank" class="feed-pill" id="rss_invalid_blocks"><img src="static/img/rss-feed-white.svg" height=12>Invalid blocks</a>
+          <a target="_blank" class="feed-pill" id="rss_lagging_nodes"><img src="static/img/rss-feed-white.svg" height=12>Lagging nodes</a>
+          <a target="_blank" class="feed-pill" id="rss_unreachable_nodes"><img src="static/img/rss-feed-white.svg" height=12>Unreachable nodes</a>
+        </div>
+      </section>
     </main>
-    <hr>
-    <footer class="container-xxl px-xl-3 mt-3">
-      <div class="row text-center">
+    <footer class="app-footer mt-4">
+      <div class="row text-center align-items-center">
         <div class="col-lg-6 p-3">
-          <span class="my-auto">
-            <a target="_blank" rel="noopener" href="https://github.com/0xb10c/fork-observer" class="text-dark text-decoration-none">
-              <img src="static/img/GitHub-Mark-64px.png" class="mx-1 invert" width=32 height=32 alt="GitHub logo">
-              <span class="text-decoration-underline">fork-observer</span>
-            </a>
-            <br>
-            <span>Issues, Feature Ideas, and Self-Hosting Instructions</span>
-          </span>
+          <a target="_blank" rel="noopener" href="https://github.com/0xb10c/fork-observer" class="footer-link">
+            <img src="static/img/GitHub-Mark-64px.png" class="invert" width=24 height=24 alt="GitHub logo">
+            <span>fork-observer</span>
+          </a>
+          <span class="text-muted-soft small d-block">Issues, Feature Ideas, and Self-Hosting Instructions</span>
         </div>
         <div class="col-lg-6 p-3">
-          <span class="my-auto" id="footer-custom"></span>
+          <span class="text-muted-soft" id="footer-custom"></span>
         </div>
       </div>
     </footer>
   </div>
+  <div id="toast" class="toast-msg"></div>
 </body>
 
 <script src="static/js/d3.v7.min.js"></script>

--- a/www/js/blocktree.js
+++ b/www/js/blocktree.js
@@ -1,6 +1,7 @@
-const NODE_SIZE = 100
+const NODE_SIZE = 120
 const MAX_USIZE = 18446744073709551615;
 const BLOCK_SIZE = 50
+const BLOCK_DEPTH = 9 // depth of the 3D extrusion (offset toward the top-right)
 const MIN_DIFFICULTY = 1
 
 const orientationSelect = d3.select("#orientation")
@@ -9,16 +10,37 @@ const orientations = {
   "bottom-to-top": {
     x: (d, _) => d.x,
     y: (d, htoi) => -htoi[d.data.data.height] * NODE_SIZE,
-    linkDir: (htoi) => d3.linkVertical().x(d => o.x(d, htoi)).y(d => o.y(d, htoi)),
+    // start the link half a depth beyond the parent's top edge, over the middle of
+    // its depth face, so it looks like it comes from the center of the 3D block.
+    linkDir: (htoi) => d3.linkVertical()
+      .source(l => [o.x(l.source, htoi) + BLOCK_DEPTH/2, o.y(l.source, htoi) - BLOCK_SIZE/2 - BLOCK_DEPTH/2])
+      .target(l => [o.x(l.target, htoi) + BLOCK_DEPTH/2, o.y(l.target, htoi) - BLOCK_DEPTH/2 - 20]),
     hidden_blocks_text: {offset_x: -15, offset_y: 0, anchor: "left"},
     block_text_rotate: -90,
+    miner_dy: BLOCK_SIZE * (3/4),
+    // To make the miner label look centered on the link between the two blocks,
+    // we move it half of BLOCK_DEPTH to the right.
+    miner_dx: BLOCK_DEPTH / 2,
+    // where the tip block should land in the viewport on the initial draw: the chain
+    // grows downward, so put the tip near the top to show less empty space.
+    tip_anchor: (w, h) => [w/2, h*0.25],
   },
   "left-to-right": {
     x: (d, htoi) => htoi[d.data.data.height] * NODE_SIZE,
     y: (d, _) => d.x,
-    linkDir: (htoi) => d3.linkHorizontal().x(d => o.x(d, htoi)).y(d => o.y(d, htoi)),
+    // start the link half a depth beyond the parent's right edge, over the middle of
+    // its depth face, so it looks like it comes from the center of the 3D block.
+    linkDir: (htoi) => d3.linkHorizontal()
+      .source(l => [o.x(l.source, htoi) + BLOCK_SIZE/2 + BLOCK_DEPTH/2, o.y(l.source, htoi) - BLOCK_DEPTH/2])
+      .target(l => [o.x(l.target, htoi), o.y(l.target, htoi) - BLOCK_DEPTH/2]),
     hidden_blocks_text: {offset_x: 0, offset_y: 15, anchor: "middle"},
     block_text_rotate: 0,
+    // the label lands above the block, over the top depth face, so it must clear it.
+    miner_dy: BLOCK_SIZE * (3/4),
+    miner_dx: 0,
+    // where the tip block should land in the viewport on the initial draw: the chain
+    // grows rightward, so put the tip near the right to show less empty space.
+    tip_anchor: (w, h) => [w*0.75, h/2],
   },
 };
 
@@ -30,20 +52,39 @@ const status_to_color = {
   "headers-only": "yellow",
 }
 
-// node status indicator
-const indicator_radius = 8
-const indicator_margin = 1
+// tip info label: a stack of colored "Nx status" boxes shown next to each tip block,
+// rotated like the miner text so it sits opposite it.
+const TIP_BOX_H = 10      // height of one status box
+const TIP_PAD_X = 2       // horizontal padding inside a box
+const TIP_ROW_GAP = 2     // gap between stacked boxes
+// order the boxes by status so they always appear in the same sequence
+const status_order = {
+  "active": 0,
+  "valid-fork": 1,
+  "valid-headers": 2,
+  "headers-only": 3,
+  "invalid": 4,
+}
 
 let o = orientations["left-to-right"];
 
+// absolute position of the current tip, remembered so the "recenter" button can
+// bring the view back to it after the user pans/zooms away
+let lastTipPos = { x: 0, y: 0 }
+
 let svg = d3
     .select("#drawing-area")
-    .style("border", "1px solid")
 
 let initialDraw = true
 
 // enables zoom and panning
-const zoom = d3.zoom().scaleExtent([0.15, 2]).on( "zoom", e => g.attr("transform", e.transform) )
+const zoom = d3.zoom().scaleExtent([0.15, 5]).on( "zoom", e => {
+  g.attr("transform", e.transform)
+  // re-measure the text-fitted boxes; their metrics can be stale if they were first
+  // sized before the text was fully laid out
+  recalc_miner_boxes()
+  recalc_tip_boxes()
+})
 svg.call(zoom)
 
 let g = svg
@@ -145,6 +186,40 @@ function draw() {
 
   const [root_node, max_height, htoi] = preprocess_data(data)
 
+  // the 3D extrusion (top + right faces) lives in its own layer below the links, so
+  // a link can pass over a block's depth and tuck behind its front face — making it
+  // look like it comes from the center of the block.
+  let backFaces = g
+    .selectAll(".block-back")
+    .data(root_node.descendants(), d => `${d.data.data.hash}-${d.data.data.height}`)
+    .join(
+      enter => {
+        let back = enter.append("g")
+          .attr("class", "block-back")
+          .attr("transform", d => "translate(" + o.x(d, htoi) + "," + o.y(d, htoi) + ")")
+        const half = BLOCK_SIZE / 2
+        const DEPTH = BLOCK_DEPTH
+        back.append("polygon")
+          .attr("class", "block-face-top")
+          .attr("points", `${-half},${-half} ${half},${-half} ${half + DEPTH},${-half - DEPTH} ${-half + DEPTH},${-half - DEPTH}`)
+        back.append("polygon")
+          .attr("class", "block-face-side")
+          .attr("points", `${half},${-half} ${half + DEPTH},${-half - DEPTH} ${half + DEPTH},${half - DEPTH} ${half},${half}`)
+        // edges of the top/side/back faces, each drawn once (the front square's edges
+        // come from the front rect's own stroke, so nothing overlaps)
+        back.append("path")
+          .attr("class", "block-edges")
+          .attr("d", `M ${-half},${-half} L ${-half + DEPTH},${-half - DEPTH} L ${half + DEPTH},${-half - DEPTH} L ${half},${-half}`
+            + ` M ${half + DEPTH},${-half - DEPTH} L ${half + DEPTH},${half - DEPTH} L ${half},${half}`)
+        return back
+      },
+      update => {
+        update.transition(d3.transition().duration(600))
+          .attr("transform", d => "translate(" + o.x(d, htoi) + "," + o.y(d, htoi) + ")")
+        return update
+      }
+    )
+
   let links = g
     .selectAll(".link-block-block")
     .data(root_node.links(), d => `${d.source.data.data.hash}-${d.target.data.data.hash}`)
@@ -152,6 +227,7 @@ function draw() {
       enter => {
         enter.append("path")
           .attr("class", "link link-block-block")
+          .attr("filter", "#url(shadow)")
           .attr("d", o.linkDir(htoi))
           .attr("stroke-dasharray", (d, x, y) => d.target.data.data.height - d.source.data.data.height == 1 ? y[x].getTotalLength() + " "  + y[x].getTotalLength() : "4 5")
           .attr("fill", "transparent")
@@ -219,10 +295,10 @@ function draw() {
           .attr("class", "block-child-group")
 
         let block_backgrounds = block_child_group.insert("rect")
-          .attr("rx", 5)
-          .attr("fill", "white")
-          .attr("stroke", d => d.data.data.difficulty_int == MIN_DIFFICULTY ? "darksalmon" : "lightgray")
+          .attr("class", "block-background")
+          .attr("stroke", d => d.data.data.difficulty_int == MIN_DIFFICULTY ? "var(--accent)" : "var(--block-stroke)")
           .attr("stroke-width", d => d.data.data.difficulty_int == MIN_DIFFICULTY ? 3 : 1)
+          .attr("stroke-linejoin", "round")
           .attr("stroke-opacity", d => d.data.data.status == "mining" ? 0.2 : 1)
           .classed("being-mined", d => d.data.data.status == "mining")
 
@@ -238,11 +314,17 @@ function draw() {
           .attr("class", "block-text")
           .text(d => d.data.data.height);
 
-        let pool_text = block_child_group
-          .insert("text")
+        // miner tag: a small background box (rect) behind the miner text. the group
+        // carries the rotation; the rect is sized to the text in a later layout pass.
+        let miner_group = block_child_group
+          .append("g")
+          .attr("class", "block-miner-group")
+        miner_group.append("rect").attr("class", "block-miner-bg")
+        let pool_text = miner_group
+          .append("text")
           .classed("block-pool-name", true)
-          .attr("transform", `rotate(${o.block_text_rotate},0,0)`)
-          .attr("dy", "4em")
+          .attr("dy", o.miner_dy)
+          .attr("dx", o.miner_dx)
           .classed("block-miner", true)
           .text(d => d.data.data.miner.length > 14 ? d.data.data.miner.substring(0, 14) + "…" : d.data.data.miner);
 
@@ -257,7 +339,7 @@ function draw() {
             .attr("y", -BLOCK_SIZE/2)
             .attr("transform", "scale(1)")
 
-          pool_text
+          miner_group
             .filter(d => d.data.data.height == max_height)
             .style("opacity", 0)
             .transition(d3.transition().duration(600))
@@ -267,7 +349,7 @@ function draw() {
             .filter(d => d.data.data.height == max_height)
             .style("font-size", "0px")
             .transition(d3.transition().duration(600))
-            .style("font-size", "10px")
+            .style("font-size", "11px")
         }
 
         return newBlocks
@@ -276,47 +358,54 @@ function draw() {
         update
           .transition(d3.transition().duration(600))
           .attr("transform", d => "translate(" + o.x(d, htoi) + "," + o.y(d, htoi) + ")")
+        // keep the stored anchor coordinates in sync (info boxes read these), or
+        // they'd stay at the previous orientation's position after a switch
+        update
+          .attr("x", d => o.x(d, htoi))
+          .attr("y", d => o.y(d, htoi))
         update.selectAll(".block-pool-name")
-          .attr("transform", `rotate(${o.block_text_rotate},0,0)`)
+          .attr("dy", o.miner_dy)
+          .attr("dx", o.miner_dx)
 
         update.raise()
         return update
       }
     );
 
+  // size the miner background box to fit its (already positioned) text
+  recalc_miner_boxes()
+
+  // tip info label: a stack of colored "Nx status" boxes next to each tip block. the
+  // whole group is rotated like the miner text so it sits on the opposite side.
   let node_groups = g
-    .selectAll(".node-tip-status-indicator")
-    .data(root_node.descendants().filter(d => d.data.data.status != "in-chain" && d.data.data.status != "mining"))
+    .selectAll(".tip-info")
+    .data(root_node.descendants().filter(d => d.data.data.status != "in-chain" && d.data.data.status != "mining"),
+      d => `${d.data.data.hash}-${d.data.data.height}`)
     .join("g")
-    .classed("node-tip-status-indicator", true)
+    .classed("tip-info", true)
     .attr("transform", d => "translate(" + o.x(d, htoi) + "," + o.y(d, htoi) + ")")
 
-  // build the rect + text once per indicator on enter, otherwise every redraw
-  // would append another copy to the existing indicator groups
-  let indicators = node_groups.selectAll("g.tip-status-indicator")
-    .data(d => d.data.data.status)
+  // build the box (rect + text + title) once per status on enter, so redraws don't
+  // accumulate copies
+  let tip_rows = node_groups.selectAll("g.tip-info-row")
+    .data(
+      d => d.data.data.status.slice().sort((a, b) => status_order[a.status] - status_order[b.status]),
+      d => d.status
+    )
     .join(enter => {
-      let group = enter.append("g").attr("class", "tip-status-indicator")
-      group.append("rect")
-        .attr("width", indicator_radius*2)
-        .attr("height", indicator_radius*2)
-        .attr("rx", 1)
-        .attr("r", indicator_radius)
-        .attr("y", -BLOCK_SIZE/2 - indicator_radius)
-      group.append("text")
-        .attr("y", -BLOCK_SIZE/2)
-        .attr("dy", ".35em")
-      return group
+      let row = enter.append("g").attr("class", "tip-info-row")
+      row.append("title")
+      row.append("rect").attr("class", "tip-info-bg")
+      row.append("text").attr("class", "tip-info-text").attr("text-anchor", "start").attr("dy", ".35em")
+      return row
     })
 
-  // refresh the parts that depend on the (possibly changed) status data
-  indicators.select("rect")
-    .attr("x", (d, i) => (BLOCK_SIZE/2) - i * (indicator_radius + indicator_margin) * 2 - indicator_radius)
-    .attr("class", d => "tip-status-color-fill-" + d.status)
+  tip_rows.select("rect").attr("class", d => "tip-info-bg tip-status-color-fill-" + d.status)
+  tip_rows.select("text").text(d => d.count + "x " + d.status)
+  tip_rows.select("title").text(d => d.nodes.map(node => node.name).join(", "))
 
-  indicators.select("text")
-    .attr("dx", (d, i) => (BLOCK_SIZE/2) - i * (indicator_radius + indicator_margin) * 2)
-    .text(d => d.count)
+  // measure each label and stack the boxes just off the block
+  recalc_tip_boxes()
 
   let offset_x = 0;
   let offset_y = 0;
@@ -326,8 +415,12 @@ function draw() {
     offset_y = o.y(max_height_tip, htoi);
   }
 
-  // raise the blocks to make sure they are drawn over the links, then the tip
-  // status markers over the blocks
+  // stack, bottom to top: 3D depth faces, then the links over them, then the block
+  // front faces (so links tuck behind the front face and look centered), then the
+  // tip status markers
+  backFaces.raise()
+  g.selectAll(".link-block-block").raise()
+  g.selectAll(".text-blocks-not-shown").raise()
   blocks.raise()
   node_groups.raise()
 
@@ -350,13 +443,57 @@ function draw() {
   })
   descLayer.raise()
 
+  lastTipPos = { x: offset_x, y: offset_y }
+
   zoom.scaleBy(svg, 1);
   let svgSize = d3.select("#drawing-area").node().getBoundingClientRect();
-  zoom.translateTo(svg.transition(d3.transition().duration(initialDraw ? 0 : 750)), offset_x, offset_y, [(svgSize.width)/2, (svgSize.height)/2])
-
-  svg.select("#legend").attr("x", svg.node().clientWidth - 150 - 10)
+  zoom.translateTo(svg.transition(d3.transition().duration(initialDraw ? 0 : 750)), offset_x, offset_y, o.tip_anchor(svgSize.width, svgSize.height))
 
   initialDraw = false
+}
+
+// bring the view back to the tip, anchored where the initial draw placed it. Keeps
+// the current zoom level; just re-pans.
+function recenter() {
+  let svgSize = d3.select("#drawing-area").node().getBoundingClientRect();
+  zoom.translateTo(svg.transition(d3.transition().duration(500)), lastTipPos.x, lastTipPos.y, o.tip_anchor(svgSize.width, svgSize.height))
+}
+
+// close every open block info box (and its connector)
+function closeAllDescriptions() {
+  descLayer.selectAll(".block-description").remove()
+  connectorLayer.selectAll(".link-block-description").remove()
+}
+
+// size each miner background box to fit its (already positioned) text. Text metrics
+// (getBBox) only become reliable once the element is laid out, so this also runs on
+// zoom to correct any boxes measured before their text was fully rendered.
+function recalc_miner_boxes() {
+  g.selectAll(".block-miner-group").each(function () {
+    let text = d3.select(this).select("text.block-miner").node()
+    let bb = text.getBBox()
+    d3.select(this).select("rect.block-miner-bg")
+      .attr("x", bb.width ? bb.x : 0).attr("y", bb.y)
+      .attr("width", bb.width ? bb.width : 0).attr("height", bb.height)
+  })
+}
+
+// measure each tip-status label and stack the boxes just off the block. Runs on draw
+// and on zoom, for the same text-metric reason as recalc_miner_boxes().
+function recalc_tip_boxes() {
+  const bottom_edge = -1 * ((BLOCK_SIZE / 2) + 3)
+  g.selectAll(".tip-info").each(function () {
+    let rows = d3.select(this).selectAll("g.tip-info-row")
+    let n = rows.size()
+    rows.each(function (d, j) {
+      let row = d3.select(this)
+      let w = row.select("text").node().getComputedTextLength() + 2 * TIP_PAD_X
+      let top_y = bottom_edge - TIP_BOX_H - (n - 1 - j) * (TIP_BOX_H + TIP_ROW_GAP)
+      row.attr("transform", "translate(" + BLOCK_DEPTH/2 + "," + top_y + ")")
+      row.select("rect").attr("x", -BLOCK_SIZE/2).attr("y", 0).attr("width", w).attr("height", TIP_BOX_H)
+      row.select("text").attr("x", -BLOCK_SIZE/2 + TIP_PAD_X).attr("y", TIP_BOX_H/2)
+    })
+  })
 }
 
 // recursivly collapses linear branches of blocks longer than x,
@@ -499,10 +636,10 @@ function onBlockClick(c, d) {
     .attr("width", "600")
   let card = cardWrapper
     .append("xhtml:div")
-      .attr("class", "card m-0 p-0 border")
-  let headerDiv = card.append("xhtml:div").attr("class", "card-header border")
+      .attr("class", "card m-0 p-0 block-info-card")
+  let headerDiv = card.append("xhtml:div").attr("class", "card-header")
   headerDiv.append()
-    .html(`<span>Header at height <span style="cursor: pointer" onClick='window.prompt("height:", "${d.data.data.height}")'>${d.data.data.height}</span></span>`)
+    .html(`<span>Header at height <span class="copyable" title="click to copy" onClick='copyToClipboard("${d.data.data.height}", "height")'>${d.data.data.height}</span></span>`)
   headerDiv.append()
     .style("float", "right")
     .html(`<button class="btn btn-close"></button>`)
@@ -514,9 +651,9 @@ function onBlockClick(c, d) {
           <div class="container">
             <div class="row small">
               <div class="col small">
-                <div class="row" style="cursor: pointer" onClick='window.prompt("hash:", "${d.data.data.hash}")'><span class="col-2">hash</span><span class="col-10 font-monospace small">${d.data.data.hash}</span></div>
-                <div class="row" style="cursor: pointer" onClick='window.prompt("previous hash:", "${d.data.data.prev_blockhash}")'><span class="col-2">previous</span><span class="col-10 font-monospace small">${d.data.data.prev_blockhash}</span></div>
-                <div class="row" style="cursor: pointer" onClick='window.prompt("merkle root:", "${d.data.data.merkle_root}")'><span class="col-2">merkleroot</span><span class="col-10 font-monospace small">${d.data.data.merkle_root}</span></div>
+                <div class="row copyable" title="click to copy" onClick='copyToClipboard("${d.data.data.hash}", "hash")'><span class="col-2">hash</span><span class="col-10 font-monospace small">${d.data.data.hash}</span></div>
+                <div class="row copyable" title="click to copy" onClick='copyToClipboard("${d.data.data.prev_blockhash}", "previous hash")'><span class="col-2">previous</span><span class="col-10 font-monospace small">${d.data.data.prev_blockhash}</span></div>
+                <div class="row copyable" title="click to copy" onClick='copyToClipboard("${d.data.data.merkle_root}", "merkle root")'><span class="col-2">merkleroot</span><span class="col-10 font-monospace small">${d.data.data.merkle_root}</span></div>
                 <div class="row">
                   <span class="col-2">timestamp</span><span class="col-4">${d.data.data.time}</span>
                   <span class="col-2">version</span><span class="col-4 font-monospace">0x${d.data.data.version.toString(16)}</span>
@@ -535,14 +672,6 @@ function onBlockClick(c, d) {
 
   // draw the connector now that the card size is known
   connector.attr("d", connectorPath())
-}
-
-function node_description(description) {
-  return `
-    <p class="mb-0 text-truncate" onclick="this.style.whiteSpace = 'normal'">
-      <span>${description}</span>
-    </p>
-  `
 }
 
 function get_active_height_or_0(node) {
@@ -594,47 +723,46 @@ function ago(timestamp) {
 
 async function draw_nodes() {
   nodeInfoRow.html(null);
-  nodeInfoRow.selectAll('.node-info')
+
+  let table = nodeInfoRow.append("table").attr("class", "node-table")
+  table.append("thead").append("tr").html(`
+    <th>node</th>
+    <th>implementation</th>
+    <th>tip changed</th>
+    <th class="nt-num">height</th>
+    <th>tip hash</th>
+  `)
+
+  table.append("tbody")
+    .selectAll("tr")
     .data(state_data.nodes.sort((a, b) => get_active_height_or_0(a) - get_active_height_or_0(b)))
     .enter()
-    .append("div")
-      .attr("class", "row-cols-auto px-1")
-      .html(d => `
-      <div class="col border rounded node-info my-2" style="min-height: 8rem; width: 16rem;">
-        <h5 class="card-title py-0 mt-1 mb-0">
-          <span class="mx-2 mt-1 d-inline-block text-truncate" style="max-width: 15rem;">
-            <img class="invert" src="static/img/node.svg" height=28 alt="Node symbol">
-            ${d.name}
-          </span>
-        </h5>
-        <div class="px-2 small">
-          ${d.reachable ? "": "<span class='badge text-bg-danger'>unreachable</span>"}
-          <span class='badge text-bg-secondary small'>${d.implementation} ${d.version.replaceAll("/", "").replaceAll("Satoshi:", "").replace("unknown", "(version unknown)")}</span>
-        </div>
-
-        <div class="px-2">
-          ${node_description(d.description)}
-        </div>
-        <div class="px-2">
-          <span class="small">tip changed <span class="relativeTimestamp" data-timestamp=${d.last_changed_timestamp}>${ago(d.last_changed_timestamp)}</span>
-        </div>
-        <div class="px-2" style="background-color: hsl(${parseInt(get_active_height_or_0(d) * 90, 10) % 360}, 50%, 75%)">
-          <span class="small text-color-dark"> height: ${get_active_height_or_0(d)}
-        </div>
-        <div class="px-2 rounded-bottom" style="background-color: hsl(${(parseInt(get_active_hash_or_fake(d).substring(58), 16) + 120) % 360}, 50%, 75%)">
-          <details>
-            <summary style="list-style: none;">
-              <span class="small text-color-dark">
-                tip hash: …${get_active_hash_or_fake(d).substring(54, 64)}
-              </span>
-            </summary>
-            <span class="small text-color-dark">
-              ${get_active_hash_or_fake(d)}
-            </span>
-          </details>
-        </div>
-      </div>
-    `)
+    .append("tr")
+      .attr("class", "node-row")
+      // expose the height/tip-hash hues as CSS vars so the height and tip-hash
+      // cells can be tinted: same height -> same height-chip color, same tip ->
+      // same hash-chip color.
+      .attr("style", d => {
+        const height_hue = parseInt(get_active_height_or_0(d) * 90, 10) % 360
+        const hash_hue = (parseInt(get_active_hash_or_fake(d).substring(58), 16) + 120) % 360
+        return `--height-hue: ${height_hue}; --hash-hue: ${hash_hue};`
+      })
+      .html(d => {
+        const height = get_active_height_or_0(d)
+        const hash = get_active_hash_or_fake(d)
+        const version = d.version.replaceAll("/", "").replaceAll("Satoshi:", "").replace("unknown", "(version unknown)")
+        return `
+        <td class="nt-name">
+          <span class="node-status-dot ${d.reachable ? "is-up" : "is-down"}" title="${d.reachable ? "reachable" : "unreachable"}"></span>
+          <span class="nt-name-text" title="${d.name}">${d.name}</span>
+          ${d.reachable ? "" : "<span class='badge text-bg-danger'>unreachable</span>"}
+          ${d.description ? `<div class="nt-desc" onclick="this.classList.toggle('nt-desc-open')">${d.description}</div>` : ""}
+        </td>
+        <td class="nt-impl">${d.implementation} ${version}</td>
+        <td class="text-muted-soft nt-time"><span class="relativeTimestamp" data-timestamp=${d.last_changed_timestamp}>${ago(d.last_changed_timestamp)}</span></td>
+        <td class="nt-num"><span class="height-chip">${height}</span></td>
+        <td><code class="hash-chip" title="click to copy full tip hash" onclick="copyToClipboard('${hash}', 'tip hash')">…${hash.substring(44, 64)}</code></td>
+      `})
 }
 
 orientationSelect.on("input", async function() {

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -121,17 +121,44 @@ function periodicallyRedrawTimestamps() {
 }
 
 changeSSE.addEventListener('open', () => {
-  connectionStatus.style("color", "green");
+  connectionStatus.style("color", "var(--tip-status-color-active)");
+  connectionStatus.attr("title", "connected — receiving live updates");
 });
 
 changeSSE.addEventListener('error', (e) => {
   console.error("SSE error", e);
-  connectionStatus.style("color", "red");
+  connectionStatus.style("color", "var(--tip-status-color-invalid)");
+  connectionStatus.attr("title", "disconnected — reconnecting…");
 });
 
 changeSSE.addEventListener('close', (e) => {
   connectionStatus.style("color", "grey");
+  connectionStatus.attr("title", "connection closed");
 });
+
+// copy text to the clipboard and confirm with a short toast
+function copyToClipboard(text, label) {
+  navigator.clipboard.writeText(text)
+    .then(() => showToast((label ? label + " " : "") + "copied to clipboard"))
+    .catch(() => showToast("could not copy to clipboard"))
+}
+
+let toastTimer = null
+function showToast(message) {
+  let toast = document.getElementById("toast")
+  if (toast == null) return
+  toast.textContent = message
+  toast.classList.add("toast-show")
+  clearTimeout(toastTimer)
+  toastTimer = setTimeout(() => toast.classList.remove("toast-show"), 1800)
+}
+
+// Escape closes any open block info boxes
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape") {
+    closeAllDescriptions()
+  }
+})
 
 changeSSE.addEventListener("cache_changed", (e) => {
   let data = JSON.parse(e.data)


### PR DESCRIPTION
This does quite a few things. Listing the biggest changes here:

- we now render blocks as "fake" 3D-blocks
- the tip-info is now a text, so it's easier to understand
- nodes are now shown in a list
- the page has been reordered to have the visualization at the top, the nodes list below it


old: 
<img width="1297" height="511" alt="image" src="https://github.com/user-attachments/assets/a1b9cd38-73d1-4d61-a539-29a36841218b" />

new: 
<img width="1352" height="532" alt="image" src="https://github.com/user-attachments/assets/7ee66ef4-06a8-4f82-8838-fd5416d7977d" />


old: 
<img width="1910" height="594" alt="image" src="https://github.com/user-attachments/assets/3f2df7a9-4e7d-4dc1-8664-98aa0a09bbdf" />


new: 
<img width="1804" height="564" alt="image" src="https://github.com/user-attachments/assets/6b675eac-256e-4950-abdc-7bf751703611" />
