### PR TITLE
Expose stale headers and stale blocks in API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -803,6 +804,7 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -1537,6 +1539,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,12 +1590,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "warp"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d06d9202adc1f15d709c4f4a2069be5428aa912cc025d6f268ac441ab066b0"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
  "headers",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ corepc-client = { version = "0.16.0", features = ["client-sync"] }
 
 [dev-dependencies]
 corepc-node = { version = "0.12.0", features = ["29_0", "download"] }
+warp = { version = "0.4.2", features = ["test"] }
 
 [features]
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,9 +1,14 @@
 use std::convert::Infallible;
+use std::str::FromStr;
 
+use corepc_client::bitcoin::BlockHash;
+use log::warn;
 use warp::{sse::Event, Filter};
 
+use crate::config::Network;
 use crate::types::{
     Caches, DataChanged, DataJsonResponse, InfoJsonResponse, NetworkJson, NetworksJsonResponse,
+    StaleBlocksJsonResponse,
 };
 
 pub async fn info_response(footer: String) -> Result<impl warp::Reply, Infallible> {
@@ -22,6 +27,153 @@ pub async fn data_response(network: u32, caches: Caches) -> Result<impl warp::Re
             nodes: vec![],
         })),
     }
+}
+
+pub async fn stale_blocks_response(
+    network: u32,
+    caches: Caches,
+) -> Result<impl warp::Reply, Infallible> {
+    let caches_locked = caches.lock().await;
+    let stale_blocks = match caches_locked.get(&network) {
+        Some(cache) => cache.stale_blocks.clone(),
+        None => vec![],
+    };
+    Ok(warp::reply::json(&StaleBlocksJsonResponse { stale_blocks }))
+}
+
+/// Serves a full block by its hash as hex (`as_hex = true`) or raw binary.
+/// We try every node we are connected to until one returns the block. We cache
+/// this response for a while.
+///
+/// Only blocks that this instance currently considers stale (i.e. present in the
+/// cached stale-blocks list) are served; any other hash returns a 404. This
+/// keeps the endpoint from acting as a general-purpose block proxy.
+pub async fn block_response(
+    network_id: u32,
+    hash: String,
+    as_hex: bool,
+    caches: Caches,
+    networks: Vec<Network>,
+) -> Result<impl warp::Reply, Infallible> {
+    let block_hash = match BlockHash::from_str(&hash) {
+        Ok(h) => h,
+        Err(e) => {
+            return Ok(warp::http::Response::builder()
+                .status(400)
+                .header("content-type", "text/plain")
+                .body(format!("Invalid block hash '{}': {}", hash, e).into_bytes())
+                .unwrap());
+        }
+    };
+
+    // We only serve blocks the instance considers stale. While holding the lock
+    // we also read any cached entry:
+    //   Some(Some(bytes)) - the block, already fetched and cached
+    //   Some(None)        - we already asked every node and none had it
+    //   None              - not yet fetched
+    let cached = {
+        let caches_locked = caches.lock().await;
+        match caches_locked.get(&network_id) {
+            Some(cache) => {
+                if !cache
+                    .stale_blocks
+                    .iter()
+                    .any(|b| b.hash == block_hash.to_string())
+                {
+                    return Ok(not_a_stale_block(block_hash, network_id));
+                }
+                cache.block_cache.get(&block_hash).cloned()
+            }
+            None => return Ok(not_a_stale_block(block_hash, network_id)),
+        }
+    };
+
+    let bytes = match cached {
+        // Cached hit.
+        Some(Some(bytes)) => bytes,
+        // We already tried every node and none had it. Don't retry.
+        Some(None) => return Ok(block_not_available(block_hash)),
+        // Not fetched yet: try every node until one returns the block, then
+        // cache the outcome (the bytes, or `None` if no node had it).
+        None => {
+            let network = match networks.iter().find(|n| n.id == network_id) {
+                Some(n) => n,
+                None => return Ok(block_not_available(block_hash)),
+            };
+
+            let mut fetched: Option<Vec<u8>> = None;
+            for node in network.nodes.iter() {
+                match node.block(&block_hash).await {
+                    Ok(bytes) => {
+                        fetched = Some(bytes);
+                        break;
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Could not fetch block {} from node {} on network {}: {}",
+                            block_hash,
+                            node.info(),
+                            network_id,
+                            e
+                        );
+                    }
+                }
+            }
+
+            // Cache the result (only while the block is still stale, so we don't
+            // reintroduce an entry that was concurrently pruned).
+            {
+                let mut caches_locked = caches.lock().await;
+                if let Some(cache) = caches_locked.get_mut(&network_id) {
+                    if cache
+                        .stale_blocks
+                        .iter()
+                        .any(|b| b.hash == block_hash.to_string())
+                    {
+                        cache.block_cache.insert(block_hash, fetched.clone());
+                    }
+                }
+            }
+
+            match fetched {
+                Some(bytes) => bytes,
+                None => return Ok(block_not_available(block_hash)),
+            }
+        }
+    };
+
+    if as_hex {
+        return Ok(warp::http::Response::builder()
+            .header("content-type", "text/plain")
+            .body(hex::encode(&bytes).into_bytes())
+            .unwrap());
+    }
+    Ok(warp::http::Response::builder()
+        .header("content-type", "application/octet-stream")
+        .body(bytes)
+        .unwrap())
+}
+
+fn not_a_stale_block(block_hash: BlockHash, network_id: u32) -> warp::http::Response<Vec<u8>> {
+    warp::http::Response::builder()
+        .status(404)
+        .header("content-type", "text/plain")
+        .body(
+            format!(
+                "Block {} is not a known stale block on network {}.",
+                block_hash, network_id
+            )
+            .into_bytes(),
+        )
+        .unwrap()
+}
+
+fn block_not_available(block_hash: BlockHash) -> warp::http::Response<Vec<u8>> {
+    warp::http::Response::builder()
+        .status(404)
+        .header("content-type", "text/plain")
+        .body(format!("Could not fetch block {} from any node.", block_hash).into_bytes())
+        .unwrap()
 }
 
 pub async fn networks_response(
@@ -50,4 +202,398 @@ pub fn with_networks(
     networks: Vec<NetworkJson>,
 ) -> impl Filter<Extract = (Vec<NetworkJson>,), Error = Infallible> + Clone {
     warp::any().map(move || networks.clone())
+}
+
+pub fn with_config_networks(
+    networks: Vec<Network>,
+) -> impl Filter<Extract = (Vec<Network>,), Error = Infallible> + Clone {
+    warp::any().map(move || networks.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{block_response, stale_blocks_response, with_caches, with_config_networks};
+    use crate::config::{BoxedSyncSendNode, Network, PoolIdentification};
+    use crate::node::{BitcoinCoreNode, NodeInfo};
+    use crate::types::{Cache, Caches, StaleBlockJson};
+    use corepc_client::bitcoin::consensus::deserialize;
+    use corepc_client::bitcoin::{Block, BlockHash};
+    use corepc_client::client_sync::Auth;
+    use std::collections::{BTreeMap, HashMap};
+    use std::str::FromStr;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+    use warp::Filter;
+
+    fn caches_with_stale(network_id: u32, stale_blocks: Vec<StaleBlockJson>) -> Caches {
+        let mut map = BTreeMap::new();
+        map.insert(
+            network_id,
+            Cache {
+                header_infos_json: vec![],
+                node_data: BTreeMap::new(),
+                forks: vec![],
+                stale_blocks,
+                block_cache: HashMap::new(),
+                recent_miners: vec![],
+            },
+        );
+        Arc::new(Mutex::new(map))
+    }
+
+    fn make_network(id: u32, nodes: Vec<BoxedSyncSendNode>) -> Network {
+        Network {
+            id,
+            description: String::new(),
+            name: format!("net{}", id),
+            min_fork_height: 0,
+            max_interesting_heights: 100,
+            nodes,
+            pool_identification: PoolIdentification::default(),
+        }
+    }
+
+    fn node_info(id: u32, name: &str) -> NodeInfo {
+        NodeInfo {
+            id,
+            name: name.to_string(),
+            description: String::new(),
+            implementation: "Bitcoin Core".to_string(),
+        }
+    }
+
+    // A node whose RPC/REST endpoint is not listening, so every request fails.
+    fn broken_core_node(id: u32) -> BoxedSyncSendNode {
+        Arc::new(BitcoinCoreNode::new(
+            node_info(id, "broken"),
+            "http://127.0.0.1:1".to_string(),
+            Auth::UserPass("user".to_string(), "pass".to_string()),
+            false, // use_rest
+            false, // use_waitfornewblock
+        ))
+    }
+
+    #[tokio::test]
+    async fn stale_json_returns_cached_blocks_in_order() {
+        let caches = caches_with_stale(
+            0,
+            vec![
+                StaleBlockJson {
+                    height: 10,
+                    hash: "aa".to_string(),
+                    header: "00".repeat(80),
+                },
+                StaleBlockJson {
+                    height: 9,
+                    hash: "bb".to_string(),
+                    header: "11".repeat(80),
+                },
+            ],
+        );
+        let route = warp::get()
+            .and(warp::path!("api" / u32 / "stale.json"))
+            .and(with_caches(caches))
+            .and_then(stale_blocks_response);
+
+        let resp = warp::test::request()
+            .path("/api/0/stale.json")
+            .reply(&route)
+            .await;
+
+        assert_eq!(resp.status(), 200);
+        let v: serde_json::Value = serde_json::from_slice(resp.body()).unwrap();
+        let arr = v["stale_blocks"].as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["hash"], "aa");
+        assert_eq!(arr[0]["height"], 10);
+        assert_eq!(arr[1]["hash"], "bb");
+    }
+
+    #[tokio::test]
+    async fn stale_json_unknown_network_is_empty() {
+        let caches = caches_with_stale(
+            0,
+            vec![StaleBlockJson {
+                height: 1,
+                hash: "aa".to_string(),
+                header: "00".repeat(80),
+            }],
+        );
+        let route = warp::get()
+            .and(warp::path!("api" / u32 / "stale.json"))
+            .and(with_caches(caches))
+            .and_then(stale_blocks_response);
+
+        let resp = warp::test::request()
+            .path("/api/99/stale.json")
+            .reply(&route)
+            .await;
+
+        assert_eq!(resp.status(), 200);
+        let v: serde_json::Value = serde_json::from_slice(resp.body()).unwrap();
+        assert_eq!(v["stale_blocks"].as_array().unwrap().len(), 0);
+    }
+
+    // Builds a caches map in which `hash` is a known stale block on `network_id`.
+    fn caches_with_stale_hash(network_id: u32, hash: &str) -> Caches {
+        caches_with_stale(
+            network_id,
+            vec![StaleBlockJson {
+                height: 1,
+                hash: hash.to_string(),
+                header: "00".repeat(80),
+            }],
+        )
+    }
+
+    fn block_hex_route(
+        caches: Caches,
+        networks: Vec<Network>,
+    ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+        warp::get()
+            .and(warp::path!("api" / u32 / "block" / String / "hex"))
+            .and(with_caches(caches))
+            .and(with_config_networks(networks))
+            .and_then(|id, hash, caches, nets| block_response(id, hash, true, caches, nets))
+    }
+
+    fn block_bin_route(
+        caches: Caches,
+        networks: Vec<Network>,
+    ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+        warp::get()
+            .and(warp::path!("api" / u32 / "block" / String / "bin"))
+            .and(with_caches(caches))
+            .and(with_config_networks(networks))
+            .and_then(|id, hash, caches, nets| block_response(id, hash, false, caches, nets))
+    }
+
+    #[tokio::test]
+    async fn block_invalid_hash_returns_400() {
+        let route = block_hex_route(
+            caches_with_stale(0, vec![]),
+            vec![make_network(0, vec![broken_core_node(0)])],
+        );
+        let resp = warp::test::request()
+            .path("/api/0/block/not-a-hash/hex")
+            .reply(&route)
+            .await;
+        assert_eq!(resp.status(), 400);
+    }
+
+    #[tokio::test]
+    async fn block_unknown_network_returns_404() {
+        let hash = "0".repeat(64);
+        let route = block_hex_route(
+            caches_with_stale_hash(0, &hash),
+            vec![make_network(0, vec![broken_core_node(0)])],
+        );
+        let resp = warp::test::request()
+            .path(&format!("/api/99/block/{}/hex", hash))
+            .reply(&route)
+            .await;
+        assert_eq!(resp.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn block_non_stale_hash_returns_404() {
+        // The network exists, but the requested block isn't a known stale block.
+        let route = block_hex_route(
+            caches_with_stale(0, vec![]),
+            vec![make_network(0, vec![broken_core_node(0)])],
+        );
+        let hash = "0".repeat(64);
+        let resp = warp::test::request()
+            .path(&format!("/api/0/block/{}/hex", hash))
+            .reply(&route)
+            .await;
+        assert_eq!(resp.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn block_all_nodes_failing_returns_502() {
+        // The block is a known stale block, so we proceed to (unsuccessfully)
+        // query the nodes.
+        let hash = "0".repeat(64);
+        let route = block_hex_route(
+            caches_with_stale_hash(0, &hash),
+            vec![make_network(0, vec![broken_core_node(0)])],
+        );
+        let resp = warp::test::request()
+            .path(&format!("/api/0/block/{}/hex", hash))
+            .reply(&route)
+            .await;
+        assert_eq!(resp.status(), 404);
+    }
+
+    // --- Tests that spin up a real regtest bitcoind ---
+
+    use corepc_node::Node as CoreNode;
+
+    fn start_bitcoind() -> CoreNode {
+        let exe = corepc_node::exe_path()
+            .expect("a bitcoind binary via BITCOIND_EXE or PATH (see shell.nix)");
+        CoreNode::new(exe).expect("failed to launch bitcoind")
+    }
+
+    fn core_node(id: u32, core: &CoreNode) -> BoxedSyncSendNode {
+        Arc::new(BitcoinCoreNode::new(
+            node_info(id, "core"),
+            core.rpc_url(),
+            Auth::CookieFile(core.params.cookie_file.clone()),
+            false, // use_rest (avoid needing bitcoind's REST interface enabled)
+            true,  // use_waitfornewblock
+        ))
+    }
+
+    #[tokio::test]
+    async fn block_endpoints_return_the_full_block() {
+        let core = start_bitcoind();
+        let address = core.client.new_address().expect("new_address failed");
+        core.client
+            .generate_to_address(3, &address)
+            .expect("generate_to_address failed");
+
+        let node = core_node(0, &core);
+        let hash = node.block_hash(2).await.expect("block_hash failed");
+        let network = make_network(0, vec![node.clone()]);
+        // Mark the block as stale so the endpoint serves it.
+        let caches = caches_with_stale_hash(0, &hash.to_string());
+
+        // hex endpoint
+        let hex_route = block_hex_route(caches.clone(), vec![network.clone()]);
+        let resp = warp::test::request()
+            .path(&format!("/api/0/block/{}/hex", hash))
+            .reply(&hex_route)
+            .await;
+        assert_eq!(resp.status(), 200);
+        let hex = std::str::from_utf8(resp.body()).expect("hex body should be utf8");
+        let bytes = hex::decode(hex).expect("body should be valid hex");
+        let block: Block = deserialize(&bytes).expect("should deserialize to a block");
+        assert_eq!(block.block_hash(), hash);
+
+        // bin endpoint
+        let bin_route = block_bin_route(caches, vec![network]);
+        let resp = warp::test::request()
+            .path(&format!("/api/0/block/{}/bin", hash))
+            .reply(&bin_route)
+            .await;
+        assert_eq!(resp.status(), 200);
+        let block: Block = deserialize(resp.body()).expect("should deserialize to a block");
+        assert_eq!(block.block_hash(), hash);
+    }
+
+    #[tokio::test]
+    async fn block_endpoint_tries_all_nodes_until_one_succeeds() {
+        let core = start_bitcoind();
+        let address = core.client.new_address().expect("new_address failed");
+        core.client
+            .generate_to_address(2, &address)
+            .expect("generate_to_address failed");
+
+        let good = core_node(1, &core);
+        let hash = good.block_hash(1).await.expect("block_hash failed");
+
+        // A broken node comes first; the handler must fall through to the good one.
+        let network = make_network(0, vec![broken_core_node(0), good.clone()]);
+        let caches = caches_with_stale_hash(0, &hash.to_string());
+        let route = block_hex_route(caches, vec![network]);
+
+        let resp = warp::test::request()
+            .path(&format!("/api/0/block/{}/hex", hash))
+            .reply(&route)
+            .await;
+
+        assert_eq!(resp.status(), 200);
+        let hex = std::str::from_utf8(resp.body()).expect("hex body should be utf8");
+        let bytes = hex::decode(hex).expect("body should be valid hex");
+        let block: Block = deserialize(&bytes).expect("should deserialize to a block");
+        assert_eq!(block.block_hash(), hash);
+    }
+
+    #[tokio::test]
+    async fn block_is_served_from_cache_after_first_fetch() {
+        let core = start_bitcoind();
+        let address = core.client.new_address().expect("new_address failed");
+        core.client
+            .generate_to_address(2, &address)
+            .expect("generate_to_address failed");
+
+        let good = core_node(0, &core);
+        let hash = good.block_hash(1).await.expect("block_hash failed");
+        let caches = caches_with_stale_hash(0, &hash.to_string());
+
+        // First fetch via a working node populates the cache.
+        let route = block_hex_route(caches.clone(), vec![make_network(0, vec![good.clone()])]);
+        let resp = warp::test::request()
+            .path(&format!("/api/0/block/{}/hex", hash))
+            .reply(&route)
+            .await;
+        assert_eq!(resp.status(), 200);
+
+        // The cache now holds the raw block bytes.
+        {
+            let locked = caches.lock().await;
+            let cached = locked
+                .get(&0)
+                .unwrap()
+                .block_cache
+                .get(&hash)
+                .cloned()
+                .expect("cache entry present")
+                .expect("cached bytes present");
+            let block: Block = deserialize(&cached).expect("cached bytes deserialize");
+            assert_eq!(block.block_hash(), hash);
+        }
+
+        // A second request whose only node is broken still succeeds: it is served
+        // from the cache and the node is never consulted.
+        let route2 = block_bin_route(
+            caches.clone(),
+            vec![make_network(0, vec![broken_core_node(1)])],
+        );
+        let resp = warp::test::request()
+            .path(&format!("/api/0/block/{}/bin", hash))
+            .reply(&route2)
+            .await;
+        assert_eq!(resp.status(), 200);
+        let block: Block = deserialize(resp.body()).expect("should deserialize to a block");
+        assert_eq!(block.block_hash(), hash);
+    }
+
+    #[tokio::test]
+    async fn missing_block_is_cached_as_none_and_not_retried() {
+        let hash = "0".repeat(64);
+        let block_hash = BlockHash::from_str(&hash).unwrap();
+        let caches = caches_with_stale_hash(0, &hash);
+        let route = block_hex_route(
+            caches.clone(),
+            vec![make_network(0, vec![broken_core_node(0)])],
+        );
+
+        let resp = warp::test::request()
+            .path(&format!("/api/0/block/{}/hex", hash))
+            .reply(&route)
+            .await;
+        assert_eq!(resp.status(), 404);
+
+        // The failure is remembered as `None` so we don't retry the nodes.
+        {
+            let locked = caches.lock().await;
+            let entry = locked
+                .get(&0)
+                .unwrap()
+                .block_cache
+                .get(&block_hash)
+                .cloned();
+            assert_eq!(entry, Some(None));
+        }
+
+        // A second request is still 404, now served from the cached `None`.
+        let resp = warp::test::request()
+            .path(&format!("/api/0/block/{}/hex", hash))
+            .reply(&route)
+            .await;
+        assert_eq!(resp.status(), 404);
+    }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,15 +1,129 @@
-use std::convert::Infallible;
-use std::str::FromStr;
-
-use corepc_client::bitcoin::BlockHash;
-use log::warn;
-use warp::{sse::Event, Filter};
-
-use crate::config::Network;
+use crate::config::{Config, Network};
+use crate::rss;
 use crate::types::{
     Caches, DataChanged, DataJsonResponse, InfoJsonResponse, NetworkJson, NetworksJsonResponse,
     StaleBlocksJsonResponse,
 };
+use corepc_client::bitcoin::BlockHash;
+use futures_util::StreamExt;
+use log::{error, warn};
+use std::convert::Infallible;
+use std::str::FromStr;
+use tokio::sync::broadcast::Sender;
+use tokio_stream::wrappers::BroadcastStream;
+use warp::{sse::Event, Filter};
+
+pub fn build_routes(
+    network_infos: &Vec<NetworkJson>,
+    config: &Config,
+    caches: &Caches,
+    cache_changed_tx_warp: Sender<u32>,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    let www_dir = warp::get()
+        .and(warp::path("static"))
+        .and(warp::fs::dir(config.www_path.clone()));
+    let index_html = warp::get()
+        .and(warp::path::end())
+        .and(warp::fs::file(config.www_path.join("index.html")));
+    let fullscreen_html = warp::get()
+        .and(warp::path!("fullscreen"))
+        .and(warp::fs::file(config.www_path.join("fullscreen.html")));
+
+    let info_json = warp::get()
+        .and(warp::path!("api" / "info.json"))
+        .and(with_footer(config.footer_html.clone()))
+        .and_then(info_response);
+
+    let data_json = warp::get()
+        .and(warp::path!("api" / u32 / "data.json"))
+        .and(with_caches(caches.clone()))
+        .and_then(data_response);
+
+    let stale_json = warp::get()
+        .and(warp::path!("api" / u32 / "stale.json"))
+        .and(with_caches(caches.clone()))
+        .and_then(stale_blocks_response);
+
+    let block_hex = warp::get()
+        .and(warp::path!("api" / u32 / "block" / String / "hex"))
+        .and(with_caches(caches.clone()))
+        .and(with_config_networks(config.networks.clone()))
+        .and_then(|network_id, hash, caches, networks| {
+            block_response(network_id, hash, true, caches, networks)
+        });
+
+    let block_bin = warp::get()
+        .and(warp::path!("api" / u32 / "block" / String / "bin"))
+        .and(with_caches(caches.clone()))
+        .and(with_config_networks(config.networks.clone()))
+        .and_then(|network_id, hash, caches, networks| {
+            block_response(network_id, hash, false, caches, networks)
+        });
+
+    let forks_rss = warp::get()
+        .and(warp::path!("rss" / u32 / "forks.xml"))
+        .and(with_caches(caches.clone()))
+        .and(with_networks(network_infos.clone()))
+        .and(rss::with_rss_base_url(config.rss_base_url.clone()))
+        .and_then(rss::forks_response);
+
+    let invalid_blocks_rss = warp::get()
+        .and(warp::path!("rss" / u32 / "invalid.xml"))
+        .and(with_caches(caches.clone()))
+        .and(with_networks(network_infos.clone()))
+        .and(rss::with_rss_base_url(config.rss_base_url.clone()))
+        .and_then(rss::invalid_blocks_response);
+
+    let lagging_nodes_rss = warp::get()
+        .and(warp::path!("rss" / u32 / "lagging.xml"))
+        .and(with_caches(caches.clone()))
+        .and(with_networks(network_infos.clone()))
+        .and(rss::with_rss_base_url(config.rss_base_url.clone()))
+        .and_then(rss::lagging_nodes_response);
+
+    let unreachable_nodes_rss = warp::get()
+        .and(warp::path!("rss" / u32 / "unreachable.xml"))
+        .and(with_caches(caches.clone()))
+        .and(with_networks(network_infos.clone()))
+        .and(rss::with_rss_base_url(config.rss_base_url.clone()))
+        .and_then(rss::unreachable_nodes_response);
+
+    let networks_json = warp::get()
+        .and(warp::path!("api" / "networks.json"))
+        .and(with_networks(network_infos.to_vec()))
+        .and_then(networks_response);
+
+    let change_sse = warp::path!("api" / "changes")
+        .and(warp::get())
+        .map(move || {
+            let changes_tx = cache_changed_tx_warp.subscribe();
+            let broadcast_stream = BroadcastStream::new(changes_tx);
+            let event_stream = broadcast_stream.map(move |d| match d {
+                Ok(d) => data_changed_sse(d),
+                Err(e) => {
+                    error!("Could not SSE notify about tip changed event: {}", e);
+                    data_changed_sse(u32::MAX)
+                }
+            });
+            let stream = warp::sse::keep_alive().stream(event_stream);
+            warp::sse::reply(stream)
+        });
+
+    www_dir
+        .or(index_html)
+        .or(fullscreen_html)
+        .or(data_json)
+        .or(stale_json)
+        .or(block_hex)
+        .or(block_bin)
+        .or(info_json)
+        .or(networks_json)
+        .or(change_sse)
+        .or(forks_rss)
+        .or(lagging_nodes_rss)
+        .or(unreachable_nodes_rss)
+        .or(invalid_blocks_rss)
+}
 
 pub async fn info_response(footer: String) -> Result<impl warp::Reply, Infallible> {
     Ok(warp::reply::json(&InfoJsonResponse { footer }))
@@ -212,10 +326,10 @@ pub fn with_config_networks(
 
 #[cfg(test)]
 mod tests {
-    use super::{block_response, stale_blocks_response, with_caches, with_config_networks};
-    use crate::config::{BoxedSyncSendNode, Network, PoolIdentification};
+    use super::build_routes;
+    use crate::config::{BoxedSyncSendNode, Config, Network, PoolIdentification};
     use crate::node::{BitcoinCoreNode, NodeInfo};
-    use crate::types::{Cache, Caches, StaleBlockJson};
+    use crate::types::{Cache, Caches, NetworkJson, StaleBlockJson};
     use corepc_client::bitcoin::consensus::deserialize;
     use corepc_client::bitcoin::{Block, BlockHash};
     use corepc_client::client_sync::Auth;
@@ -290,10 +404,7 @@ mod tests {
                 },
             ],
         );
-        let route = warp::get()
-            .and(warp::path!("api" / u32 / "stale.json"))
-            .and(with_caches(caches))
-            .and_then(stale_blocks_response);
+        let route = routes(caches, vec![make_network(0, vec![])]);
 
         let resp = warp::test::request()
             .path("/api/0/stale.json")
@@ -319,10 +430,7 @@ mod tests {
                 header: "00".repeat(80),
             }],
         );
-        let route = warp::get()
-            .and(warp::path!("api" / u32 / "stale.json"))
-            .and(with_caches(caches))
-            .and_then(stale_blocks_response);
+        let route = routes(caches, vec![make_network(0, vec![])]);
 
         let resp = warp::test::request()
             .path("/api/99/stale.json")
@@ -346,31 +454,33 @@ mod tests {
         )
     }
 
-    fn block_hex_route(
-        caches: Caches,
-        networks: Vec<Network>,
-    ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-        warp::get()
-            .and(warp::path!("api" / u32 / "block" / String / "hex"))
-            .and(with_caches(caches))
-            .and(with_config_networks(networks))
-            .and_then(|id, hash, caches, nets| block_response(id, hash, true, caches, nets))
+    fn test_config(networks: Vec<Network>) -> Config {
+        Config {
+            database_path: std::path::PathBuf::new(),
+            www_path: std::path::PathBuf::new(),
+            query_interval: std::time::Duration::from_secs(1),
+            address: "127.0.0.1:0".parse().unwrap(),
+            networks,
+            footer_html: String::new(),
+            rss_base_url: String::new(),
+        }
     }
 
-    fn block_bin_route(
+    // Builds the real application routes (via `build_routes`) so tests exercise
+    // the same route wiring the server uses in production.
+    fn routes(
         caches: Caches,
         networks: Vec<Network>,
-    ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-        warp::get()
-            .and(warp::path!("api" / u32 / "block" / String / "bin"))
-            .and(with_caches(caches))
-            .and(with_config_networks(networks))
-            .and_then(|id, hash, caches, nets| block_response(id, hash, false, caches, nets))
+    ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+        let network_infos: Vec<NetworkJson> = networks.iter().map(NetworkJson::new).collect();
+        let config = test_config(networks);
+        let (cache_changed_tx, _rx) = tokio::sync::broadcast::channel(16);
+        build_routes(&network_infos, &config, &caches, cache_changed_tx)
     }
 
     #[tokio::test]
     async fn block_invalid_hash_returns_400() {
-        let route = block_hex_route(
+        let route = routes(
             caches_with_stale(0, vec![]),
             vec![make_network(0, vec![broken_core_node(0)])],
         );
@@ -384,7 +494,7 @@ mod tests {
     #[tokio::test]
     async fn block_unknown_network_returns_404() {
         let hash = "0".repeat(64);
-        let route = block_hex_route(
+        let route = routes(
             caches_with_stale_hash(0, &hash),
             vec![make_network(0, vec![broken_core_node(0)])],
         );
@@ -398,7 +508,7 @@ mod tests {
     #[tokio::test]
     async fn block_non_stale_hash_returns_404() {
         // The network exists, but the requested block isn't a known stale block.
-        let route = block_hex_route(
+        let route = routes(
             caches_with_stale(0, vec![]),
             vec![make_network(0, vec![broken_core_node(0)])],
         );
@@ -415,7 +525,7 @@ mod tests {
         // The block is a known stale block, so we proceed to (unsuccessfully)
         // query the nodes.
         let hash = "0".repeat(64);
-        let route = block_hex_route(
+        let route = routes(
             caches_with_stale_hash(0, &hash),
             vec![make_network(0, vec![broken_core_node(0)])],
         );
@@ -460,11 +570,12 @@ mod tests {
         // Mark the block as stale so the endpoint serves it.
         let caches = caches_with_stale_hash(0, &hash.to_string());
 
+        let route = routes(caches, vec![network]);
+
         // hex endpoint
-        let hex_route = block_hex_route(caches.clone(), vec![network.clone()]);
         let resp = warp::test::request()
             .path(&format!("/api/0/block/{}/hex", hash))
-            .reply(&hex_route)
+            .reply(&route)
             .await;
         assert_eq!(resp.status(), 200);
         let hex = std::str::from_utf8(resp.body()).expect("hex body should be utf8");
@@ -473,10 +584,9 @@ mod tests {
         assert_eq!(block.block_hash(), hash);
 
         // bin endpoint
-        let bin_route = block_bin_route(caches, vec![network]);
         let resp = warp::test::request()
             .path(&format!("/api/0/block/{}/bin", hash))
-            .reply(&bin_route)
+            .reply(&route)
             .await;
         assert_eq!(resp.status(), 200);
         let block: Block = deserialize(resp.body()).expect("should deserialize to a block");
@@ -497,7 +607,7 @@ mod tests {
         // A broken node comes first; the handler must fall through to the good one.
         let network = make_network(0, vec![broken_core_node(0), good.clone()]);
         let caches = caches_with_stale_hash(0, &hash.to_string());
-        let route = block_hex_route(caches, vec![network]);
+        let route = routes(caches, vec![network]);
 
         let resp = warp::test::request()
             .path(&format!("/api/0/block/{}/hex", hash))
@@ -524,7 +634,7 @@ mod tests {
         let caches = caches_with_stale_hash(0, &hash.to_string());
 
         // First fetch via a working node populates the cache.
-        let route = block_hex_route(caches.clone(), vec![make_network(0, vec![good.clone()])]);
+        let route = routes(caches.clone(), vec![make_network(0, vec![good.clone()])]);
         let resp = warp::test::request()
             .path(&format!("/api/0/block/{}/hex", hash))
             .reply(&route)
@@ -548,7 +658,7 @@ mod tests {
 
         // A second request whose only node is broken still succeeds: it is served
         // from the cache and the node is never consulted.
-        let route2 = block_bin_route(
+        let route2 = routes(
             caches.clone(),
             vec![make_network(0, vec![broken_core_node(1)])],
         );
@@ -566,7 +676,7 @@ mod tests {
         let hash = "0".repeat(64);
         let block_hash = BlockHash::from_str(&hash).unwrap();
         let caches = caches_with_stale_hash(0, &hash);
-        let route = block_hex_route(
+        let route = routes(
             caches.clone(),
             vec![make_network(0, vec![broken_core_node(0)])],
         );

--- a/src/headertree.rs
+++ b/src/headertree.rs
@@ -1,8 +1,11 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::collections::HashMap;
+use std::collections::HashSet;
 
-use crate::types::{Fork, HeaderInfoJson, Tree};
+use crate::types::{Fork, HeaderInfoJson, StaleBlockJson, Tree};
 
+use corepc_client::bitcoin::pow::Work;
 use log::{debug, warn};
 use petgraph::graph::NodeIndex;
 use petgraph::visit::{Dfs, EdgeRef};
@@ -170,6 +173,86 @@ pub async fn strip_tree(
     headers
 }
 
+// Collect the stale blocks we know about. A stale block is any block that is
+// not part of the active chain. This includes stale tips as well as intermediate
+// (non-tip) stale blocks.
+//
+// The active chain is the chain with the most accumulated proof of work (its tip
+// being the block with the highest cumulative work). This mirrors how Bitcoin
+// itself picks the best chain and doesn't rely on the (possibly lagging or
+// missing) chain-tip status the nodes report. Every block that is not an
+// ancestor of - or - the most-work tip is stale.
+//
+// The `how_many` highest (most recent) stale blocks are returned.
+pub async fn stale_blocks(tree: &Tree, how_many: usize) -> Vec<StaleBlockJson> {
+    let tree_locked = tree.lock().await;
+    let graph = &tree_locked.0;
+
+    if graph.node_count() == 0 {
+        return vec![];
+    }
+
+    // Compute the cumulative work for every block. Each block links to a single
+    // parent (by prev_blockhash) and a parent always has a lower height than its
+    // child, so processing blocks in ascending height order guarantees a block's
+    // parent is processed before the block itself.
+    let mut order: Vec<NodeIndex> = graph.node_indices().collect();
+    order.sort_by_key(|idx| graph[*idx].height);
+
+    let mut cumulative_work: HashMap<NodeIndex, Work> = HashMap::new();
+    for idx in order.iter() {
+        let own_work = graph[*idx].header.work();
+        let total = match graph
+            .neighbors_directed(*idx, petgraph::Direction::Incoming)
+            .next()
+        {
+            // The parent is present and (being lower) already has its cumulative
+            // work computed.
+            Some(parent) => match cumulative_work.get(&parent) {
+                Some(parent_work) => *parent_work + own_work,
+                None => own_work,
+            },
+            // No parent in the tree (a root / the base of what we track).
+            None => own_work,
+        };
+        cumulative_work.insert(*idx, total);
+    }
+
+    // The active chain ends at the block with the most cumulative work.
+    let active_tip = order.iter().copied().max_by(|a, b| {
+        cumulative_work[a]
+            .partial_cmp(&cumulative_work[b])
+            .expect("work is always comparable")
+    });
+
+    // Walk back from the most-work tip to the root, marking the active chain.
+    let mut active: HashSet<NodeIndex> = HashSet::new();
+    if let Some(tip) = active_tip {
+        let mut current = Some(tip);
+        while let Some(idx) = current {
+            // If we've already visited this block, its ancestors are visited too.
+            if !active.insert(idx) {
+                break;
+            }
+            current = graph
+                .neighbors_directed(idx, petgraph::Direction::Incoming)
+                .next();
+        }
+    }
+
+    // Every block that isn't on the active chain is stale.
+    let mut stale: Vec<StaleBlockJson> = graph
+        .node_indices()
+        .filter(|idx| !active.contains(idx))
+        .map(|idx| StaleBlockJson::new(&graph[idx]))
+        .collect();
+
+    // Return the most recent (highest) stale blocks first, capped at `how_many`.
+    stale.sort_by(|a, b| b.height.cmp(&a.height));
+    stale.truncate(how_many);
+    stale
+}
+
 // get recent forks for rss
 pub async fn recent_forks(tree: &Tree, how_many: usize) -> Vec<Fork> {
     let tree_locked = tree.lock().await;
@@ -198,4 +281,162 @@ pub async fn recent_forks(tree: &Tree, how_many: usize) -> Vec<Fork> {
 
     forks.sort_by_key(|f| f.common.height);
     forks.iter().rev().take(how_many).cloned().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::stale_blocks;
+    use crate::types::{HeaderInfo, Tree, TreeInfo};
+    use corepc_client::bitcoin::blockdata::block::{Header, Version};
+    use corepc_client::bitcoin::hashes::Hash;
+    use corepc_client::bitcoin::{BlockHash, CompactTarget, TxMerkleNode};
+    use petgraph::graph::DiGraph;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    // The regtest target - each such block carries very little work.
+    const EASY_BITS: u32 = 0x207f_ffff;
+    // A much harder target (the mainnet genesis "difficulty 1" target). A single
+    // block at this target carries far more work than many EASY_BITS blocks.
+    const HARD_BITS: u32 = 0x1d00_ffff;
+
+    // Builds a (structurally valid, PoW-invalid) header. The nonce is used to
+    // give headers that share a parent hash distinct block hashes.
+    fn header(prev: BlockHash, bits: u32, nonce: u32) -> Header {
+        Header {
+            version: Version::from_consensus(0x2000_0000),
+            prev_blockhash: prev,
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 1_600_000_000,
+            bits: CompactTarget::from_consensus(bits),
+            nonce,
+        }
+    }
+
+    fn hi(height: u64, header: Header) -> HeaderInfo {
+        HeaderInfo {
+            height,
+            header,
+            miner: String::new(),
+        }
+    }
+
+    fn tree_from(headers: &[HeaderInfo]) -> Tree {
+        let mut graph: DiGraph<HeaderInfo, bool> = DiGraph::new();
+        let mut index: HashMap<BlockHash, _> = HashMap::new();
+        for h in headers {
+            let idx = graph.add_node(h.clone());
+            index.insert(h.header.block_hash(), idx);
+        }
+        for h in headers {
+            let current = index[&h.header.block_hash()];
+            if let Some(prev) = index.get(&h.header.prev_blockhash) {
+                graph.update_edge(*prev, current, false);
+            }
+        }
+        let tree_info: TreeInfo = (graph, index);
+        Arc::new(Mutex::new(tree_info))
+    }
+
+    #[tokio::test]
+    async fn most_work_chain_wins_keeps_intermediate_stale() {
+        // All blocks share the same (easy) work, so the most-work chain is the
+        // longest one.
+        //   root(0) -> a(1) -> b(2) -> e(3) -> f(4)   [active, cumulative 5w]
+        //                   \-> c(2) -> d(3)          [stale, cumulative 4w]
+        let root = hi(0, header(BlockHash::all_zeros(), EASY_BITS, 0));
+        let a = hi(1, header(root.header.block_hash(), EASY_BITS, 1));
+        let b = hi(2, header(a.header.block_hash(), EASY_BITS, 2));
+        let e = hi(3, header(b.header.block_hash(), EASY_BITS, 3));
+        let f = hi(4, header(e.header.block_hash(), EASY_BITS, 4));
+        let c = hi(2, header(a.header.block_hash(), EASY_BITS, 5));
+        let d = hi(3, header(c.header.block_hash(), EASY_BITS, 6));
+        let tree = tree_from(&[
+            root.clone(),
+            a.clone(),
+            b.clone(),
+            e.clone(),
+            f.clone(),
+            c.clone(),
+            d.clone(),
+        ]);
+
+        let stale = stale_blocks(&tree, 50).await;
+
+        // Only the fork blocks c and d are stale, highest first. d is the stale
+        // tip and c is a non-tip (intermediate) stale block.
+        assert_eq!(stale.len(), 2);
+        assert_eq!(stale[0].hash, d.header.block_hash().to_string());
+        assert_eq!(stale[0].height, 3);
+        assert_eq!(stale[1].hash, c.header.block_hash().to_string());
+        assert_eq!(stale[1].height, 2);
+
+        let hashes: Vec<String> = stale.iter().map(|s| s.hash.clone()).collect();
+        for on_active_chain in [&root, &a, &b, &e, &f] {
+            assert!(!hashes.contains(&on_active_chain.header.block_hash().to_string()));
+        }
+
+        // header is the hex-encoded 80-byte block header.
+        assert_eq!(stale[0].header.len(), 160);
+    }
+
+    #[tokio::test]
+    async fn picks_most_work_not_most_blocks() {
+        // A single high-work block outweighs a longer chain of low-work blocks.
+        //   root(0) -> h(1, HARD)                        [active, most work]
+        //           \-> s1(1) -> s2(2) -> s3(3) (EASY)   [stale, higher but weaker]
+        let root = hi(0, header(BlockHash::all_zeros(), EASY_BITS, 0));
+        let h = hi(1, header(root.header.block_hash(), HARD_BITS, 1));
+        let s1 = hi(1, header(root.header.block_hash(), EASY_BITS, 2));
+        let s2 = hi(2, header(s1.header.block_hash(), EASY_BITS, 3));
+        let s3 = hi(3, header(s2.header.block_hash(), EASY_BITS, 4));
+        let tree = tree_from(&[root.clone(), h.clone(), s1.clone(), s2.clone(), s3.clone()]);
+
+        let stale = stale_blocks(&tree, 50).await;
+
+        // The three easy blocks are stale even though s3 (height 3) is higher
+        // than the active tip h (height 1).
+        let hashes: Vec<String> = stale.iter().map(|s| s.hash.clone()).collect();
+        assert_eq!(stale.len(), 3);
+        assert!(hashes.contains(&s1.header.block_hash().to_string()));
+        assert!(hashes.contains(&s2.header.block_hash().to_string()));
+        assert!(hashes.contains(&s3.header.block_hash().to_string()));
+        assert!(!hashes.contains(&h.header.block_hash().to_string()));
+        assert!(!hashes.contains(&root.header.block_hash().to_string()));
+    }
+
+    #[tokio::test]
+    async fn respects_the_limit_returning_most_recent() {
+        // A long main chain (heights 0..=8, cumulative 9w) and a shorter stale
+        // branch of 5 blocks (heights 2..=6, cumulative <= 7w) forking off `a`.
+        let root = hi(0, header(BlockHash::all_zeros(), EASY_BITS, 0));
+        let a = hi(1, header(root.header.block_hash(), EASY_BITS, 1));
+        let mut headers = vec![root, a.clone()];
+
+        // main chain continues from `a` up to height 8.
+        let mut prev = a.header.block_hash();
+        for height in 2..=8u64 {
+            let block = hi(height, header(prev, EASY_BITS, 10 + height as u32));
+            prev = block.header.block_hash();
+            headers.push(block);
+        }
+
+        // stale branch of 5 blocks (heights 2..=6) forking off `a`.
+        let mut prev = a.header.block_hash();
+        for i in 0..5u32 {
+            let block = hi(2 + i as u64, header(prev, EASY_BITS, 100 + i));
+            prev = block.header.block_hash();
+            headers.push(block);
+        }
+        let tree = tree_from(&headers);
+
+        let stale = stale_blocks(&tree, 3).await;
+
+        // 5 stale blocks exist, but we cap at 3 and return the highest.
+        assert_eq!(stale.len(), 3);
+        assert_eq!(stale[0].height, 6);
+        assert_eq!(stale[1].height, 5);
+        assert_eq!(stale[2].height, 4);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@ use bitcoin_pool_identification::{default_data, PoolIdentification};
 use corepc_client::bitcoin::{BlockHash, Network};
 use corepc_client::client_sync::Error::JsonRpc;
 use env_logger::Env;
-use futures_util::StreamExt;
 use log::{debug, error, info, warn};
 use petgraph::graph::NodeIndex;
 use rusqlite::Connection;
@@ -16,8 +15,6 @@ use tokio::sync::mpsc::unbounded_channel;
 use tokio::sync::{broadcast, Mutex};
 use tokio::task;
 use tokio::time::{interval, sleep, Duration};
-use tokio_stream::wrappers::BroadcastStream;
-use warp::Filter;
 
 mod api;
 mod config;
@@ -510,110 +507,7 @@ async fn main() -> Result<(), MainError> {
         });
     }
 
-    let www_dir = warp::get()
-        .and(warp::path("static"))
-        .and(warp::fs::dir(config.www_path.clone()));
-    let index_html = warp::get()
-        .and(warp::path::end())
-        .and(warp::fs::file(config.www_path.join("index.html")));
-    let fullscreen_html = warp::get()
-        .and(warp::path!("fullscreen"))
-        .and(warp::fs::file(config.www_path.join("fullscreen.html")));
-
-    let info_json = warp::get()
-        .and(warp::path!("api" / "info.json"))
-        .and(api::with_footer(config.footer_html.clone()))
-        .and_then(api::info_response);
-
-    let data_json = warp::get()
-        .and(warp::path!("api" / u32 / "data.json"))
-        .and(api::with_caches(caches.clone()))
-        .and_then(api::data_response);
-
-    let stale_json = warp::get()
-        .and(warp::path!("api" / u32 / "stale.json"))
-        .and(api::with_caches(caches.clone()))
-        .and_then(api::stale_blocks_response);
-
-    let block_hex = warp::get()
-        .and(warp::path!("api" / u32 / "block" / String / "hex"))
-        .and(api::with_caches(caches.clone()))
-        .and(api::with_config_networks(config.networks.clone()))
-        .and_then(|network_id, hash, caches, networks| {
-            api::block_response(network_id, hash, true, caches, networks)
-        });
-
-    let block_bin = warp::get()
-        .and(warp::path!("api" / u32 / "block" / String / "bin"))
-        .and(api::with_caches(caches.clone()))
-        .and(api::with_config_networks(config.networks.clone()))
-        .and_then(|network_id, hash, caches, networks| {
-            api::block_response(network_id, hash, false, caches, networks)
-        });
-
-    let forks_rss = warp::get()
-        .and(warp::path!("rss" / u32 / "forks.xml"))
-        .and(api::with_caches(caches.clone()))
-        .and(api::with_networks(network_infos.clone()))
-        .and(rss::with_rss_base_url(config.rss_base_url.clone()))
-        .and_then(rss::forks_response);
-
-    let invalid_blocks_rss = warp::get()
-        .and(warp::path!("rss" / u32 / "invalid.xml"))
-        .and(api::with_caches(caches.clone()))
-        .and(api::with_networks(network_infos.clone()))
-        .and(rss::with_rss_base_url(config.rss_base_url.clone()))
-        .and_then(rss::invalid_blocks_response);
-
-    let lagging_nodes_rss = warp::get()
-        .and(warp::path!("rss" / u32 / "lagging.xml"))
-        .and(api::with_caches(caches.clone()))
-        .and(api::with_networks(network_infos.clone()))
-        .and(rss::with_rss_base_url(config.rss_base_url.clone()))
-        .and_then(rss::lagging_nodes_response);
-
-    let unreachable_nodes_rss = warp::get()
-        .and(warp::path!("rss" / u32 / "unreachable.xml"))
-        .and(api::with_caches(caches.clone()))
-        .and(api::with_networks(network_infos.clone()))
-        .and(rss::with_rss_base_url(config.rss_base_url.clone()))
-        .and_then(rss::unreachable_nodes_response);
-
-    let networks_json = warp::get()
-        .and(warp::path!("api" / "networks.json"))
-        .and(api::with_networks(network_infos))
-        .and_then(api::networks_response);
-
-    let change_sse = warp::path!("api" / "changes")
-        .and(warp::get())
-        .map(move || {
-            let changes_tx = cache_changed_tx_warp.subscribe();
-            let broadcast_stream = BroadcastStream::new(changes_tx);
-            let event_stream = broadcast_stream.map(move |d| match d {
-                Ok(d) => api::data_changed_sse(d),
-                Err(e) => {
-                    error!("Could not SSE notify about tip changed event: {}", e);
-                    api::data_changed_sse(u32::MAX)
-                }
-            });
-            let stream = warp::sse::keep_alive().stream(event_stream);
-            warp::sse::reply(stream)
-        });
-
-    let routes = www_dir
-        .or(index_html)
-        .or(fullscreen_html)
-        .or(data_json)
-        .or(stale_json)
-        .or(block_hex)
-        .or(block_bin)
-        .or(info_json)
-        .or(networks_json)
-        .or(change_sse)
-        .or(forks_rss)
-        .or(lagging_nodes_rss)
-        .or(unreachable_nodes_rss)
-        .or(invalid_blocks_rss);
+    let routes = api::build_routes(&network_infos, &config, &caches, cache_changed_tx_warp);
 
     warp::serve(routes).run(config.address).await;
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use log::{debug, error, info, warn};
 use petgraph::graph::NodeIndex;
 use rusqlite::Connection;
 use std::cmp::max;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt;
 use std::sync::Arc;
 use tokio::sync::mpsc::unbounded_channel;
@@ -33,12 +33,13 @@ use crate::config::BoxedSyncSendNode;
 use crate::error::{DbError, MainError};
 use types::{
     Cache, Caches, ChainTip, Db, Fork, HeaderInfo, HeaderInfoJson, NetworkJson, NodeData,
-    NodeDataJson, Tree,
+    NodeDataJson, StaleBlockJson, Tree,
 };
 
 const VERSION_UNKNOWN: &str = "unknown";
 const MINER_UNKNOWN: &str = "Unknown";
 const MAX_FORKS_IN_CACHE: usize = 50;
+const MAX_STALE_BLOCKS: usize = 50;
 
 async fn startup() -> Result<(config::Config, Db, Caches), MainError> {
     let config: config::Config = match config::load_config() {
@@ -85,6 +86,7 @@ async fn startup() -> Result<(config::Config, Db, Caches), MainError> {
 async fn populate_cache(network: &config::Network, tree: &Tree, caches: &Caches) {
     let forks = headertree::recent_forks(&tree, MAX_FORKS_IN_CACHE).await;
     let hij = headertree::strip_tree(&tree, network.max_interesting_heights, BTreeSet::new()).await;
+    let stale_blocks = headertree::stale_blocks(&tree, MAX_STALE_BLOCKS).await;
     {
         let mut locked_caches = caches.lock().await;
         let node_data: NodeData = network
@@ -110,6 +112,8 @@ async fn populate_cache(network: &config::Network, tree: &Tree, caches: &Caches)
                 header_infos_json: hij.clone(),
                 node_data,
                 forks,
+                stale_blocks,
+                block_cache: HashMap::new(),
                 recent_miners: vec![],
             },
         );
@@ -328,6 +332,8 @@ async fn main() -> Result<(), MainError> {
                             .await;
                             let forks =
                                 headertree::recent_forks(&tree_clone, MAX_FORKS_IN_CACHE).await;
+                            let stale_blocks =
+                                headertree::stale_blocks(&tree_clone, MAX_STALE_BLOCKS).await;
 
                             update_cache(
                                 &caches_clone,
@@ -335,6 +341,7 @@ async fn main() -> Result<(), MainError> {
                                 CacheUpdate::HeaderTree {
                                     header_infos_json,
                                     forks,
+                                    stale_blocks,
                                 },
                                 &cache_changed_tx_cloned,
                             )
@@ -523,6 +530,27 @@ async fn main() -> Result<(), MainError> {
         .and(api::with_caches(caches.clone()))
         .and_then(api::data_response);
 
+    let stale_json = warp::get()
+        .and(warp::path!("api" / u32 / "stale.json"))
+        .and(api::with_caches(caches.clone()))
+        .and_then(api::stale_blocks_response);
+
+    let block_hex = warp::get()
+        .and(warp::path!("api" / u32 / "block" / String / "hex"))
+        .and(api::with_caches(caches.clone()))
+        .and(api::with_config_networks(config.networks.clone()))
+        .and_then(|network_id, hash, caches, networks| {
+            api::block_response(network_id, hash, true, caches, networks)
+        });
+
+    let block_bin = warp::get()
+        .and(warp::path!("api" / u32 / "block" / String / "bin"))
+        .and(api::with_caches(caches.clone()))
+        .and(api::with_config_networks(config.networks.clone()))
+        .and_then(|network_id, hash, caches, networks| {
+            api::block_response(network_id, hash, false, caches, networks)
+        });
+
     let forks_rss = warp::get()
         .and(warp::path!("rss" / u32 / "forks.xml"))
         .and(api::with_caches(caches.clone()))
@@ -576,6 +604,9 @@ async fn main() -> Result<(), MainError> {
         .or(index_html)
         .or(fullscreen_html)
         .or(data_json)
+        .or(stale_json)
+        .or(block_hex)
+        .or(block_bin)
         .or(info_json)
         .or(networks_json)
         .or(change_sse)
@@ -618,6 +649,7 @@ enum CacheUpdate {
     HeaderTree {
         header_infos_json: Vec<HeaderInfoJson>,
         forks: Vec<Fork>,
+        stale_blocks: Vec<StaleBlockJson>,
     },
     NodeTips {
         node_id: u32,
@@ -718,6 +750,7 @@ async fn update_cache(
         CacheUpdate::HeaderTree {
             header_infos_json,
             forks,
+            stale_blocks,
         } => {
             let mut new_header_infos_map: HashMap<String, HeaderInfoJson> = header_infos_json
                 .iter()
@@ -735,12 +768,19 @@ async fn update_cache(
                 });
             }
 
+            let stale_hashes: HashSet<String> =
+                stale_blocks.iter().map(|b| b.hash.clone()).collect();
             locked_cache.entry(network_id).and_modify(|e| {
                 e.header_infos_json = new_header_infos_map
                     .iter()
                     .map(|(_, header)| header.clone())
                     .collect();
                 e.forks = forks;
+                e.stale_blocks = stale_blocks;
+                // Drop cached blocks that are no longer in the stale list, so the
+                // block cache stays bounded to the last MAX_STALE_BLOCKS blocks.
+                e.block_cache
+                    .retain(|hash, _| stale_hashes.contains(&hash.to_string()));
             });
         }
         CacheUpdate::NodeTips { node_id, tips } => {
@@ -907,6 +947,8 @@ mod tests {
                     header_infos_json: vec![],
                     node_data,
                     forks: vec![],
+                    stale_blocks: vec![],
+                    block_cache: HashMap::new(),
                     recent_miners: vec![],
                 },
             );
@@ -945,5 +987,63 @@ mod tests {
             get_test_node_reachable(&caches, network_id, node.id).await,
             true
         );
+    }
+
+    #[tokio::test]
+    async fn header_tree_update_prunes_block_cache() {
+        use crate::types::StaleBlockJson;
+        use std::str::FromStr;
+
+        let network_id: u32 = 0;
+        let (dummy_sender, _) = broadcast::channel(2);
+        let caches: Caches = Arc::new(Mutex::new(BTreeMap::new()));
+
+        let keep =
+            BlockHash::from_str("00000000000000000000000000000000000000000000000000000000000000aa")
+                .unwrap();
+        let drop_it =
+            BlockHash::from_str("00000000000000000000000000000000000000000000000000000000000000bb")
+                .unwrap();
+
+        {
+            let mut locked = caches.lock().await;
+            let mut block_cache = HashMap::new();
+            block_cache.insert(keep, Some(vec![1u8, 2, 3]));
+            block_cache.insert(drop_it, Some(vec![4u8, 5, 6]));
+            locked.insert(
+                network_id,
+                Cache {
+                    header_infos_json: vec![],
+                    node_data: BTreeMap::new(),
+                    forks: vec![],
+                    stale_blocks: vec![],
+                    block_cache,
+                    recent_miners: vec![],
+                },
+            );
+        }
+
+        // After a header-tree update whose stale list only contains `keep`, the
+        // cached block for `drop_it` must be pruned.
+        update_cache(
+            &caches,
+            network_id,
+            CacheUpdate::HeaderTree {
+                header_infos_json: vec![],
+                forks: vec![],
+                stale_blocks: vec![StaleBlockJson {
+                    height: 1,
+                    hash: keep.to_string(),
+                    header: "00".repeat(80),
+                }],
+            },
+            &dummy_sender,
+        )
+        .await;
+
+        let locked = caches.lock().await;
+        let block_cache = &locked.get(&network_id).unwrap().block_cache;
+        assert!(block_cache.contains_key(&keep));
+        assert!(!block_cache.contains_key(&drop_it));
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -48,6 +48,9 @@ pub trait Node: Sync {
     async fn block_hash(&self, height: u64) -> Result<BlockHash, FetchError>;
     async fn tips(&self) -> Result<Vec<ChainTip>, FetchError>;
     async fn coinbase(&self, hash: &BlockHash, height: u64) -> Result<Transaction, FetchError>;
+    /// Fetches a full block by its hash, returning the consensus-serialized
+    /// (raw) block bytes. Used to serve full stale blocks on demand.
+    async fn block(&self, hash: &BlockHash) -> Result<Vec<u8>, FetchError>;
     /// Fetches a batch of successive headers from the active chain.
     async fn batch_header_fetch(
         &self,
@@ -384,6 +387,33 @@ impl Node for BitcoinCoreNode {
         }
     }
 
+    async fn block(&self, hash: &BlockHash) -> Result<Vec<u8>, FetchError> {
+        // Prefer the REST interface (if enabled) as it returns the raw block
+        // bytes directly and doesn't need an extra (de)serialization roundtrip.
+        if self.use_rest {
+            let url = format!("{}/rest/block/{}.bin", self.rpc_url(), hash);
+            let res = minreq::get(url.clone()).with_timeout(8).send()?;
+            if res.status_code != 200 {
+                return Err(FetchError::BitcoinCoreREST(format!(
+                    "could not load block from REST URL ({}): {} {}: {:?}",
+                    url,
+                    res.status_code,
+                    res.reason_phrase,
+                    res.as_str(),
+                )));
+            }
+            return Ok(res.as_bytes().to_vec());
+        }
+
+        let rpc = self.rpc_client()?;
+        let hash_clone = *hash;
+        match task::spawn_blocking(move || rpc.get_block(hash_clone)).await {
+            Ok(Ok(block)) => Ok(corepc_client::bitcoin::consensus::encode::serialize(&block)),
+            Ok(Err(e)) => Err(e.into()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
     async fn tips(&self) -> Result<Vec<ChainTip>, FetchError> {
         let rpc = self.rpc_client()?;
         task::spawn_blocking(move || -> Result<Vec<ChainTip>, FetchError> {
@@ -570,6 +600,19 @@ impl Node for BtcdNode {
         }
     }
 
+    async fn block(&self, hash: &BlockHash) -> Result<Vec<u8>, FetchError> {
+        let url = format!("{}/", self.rpc_url);
+        match crate::jsonrpc::btcd_block(
+            url,
+            self.rpc_user.clone(),
+            self.rpc_password.clone(),
+            hash.to_string(),
+        ) {
+            Ok(block) => Ok(corepc_client::bitcoin::consensus::encode::serialize(&block)),
+            Err(error) => Err(FetchError::BtcdRPC(error)),
+        }
+    }
+
     async fn block_hash(&self, height: u64) -> Result<BlockHash, FetchError> {
         let url = format!("{}/", self.rpc_url);
         match crate::jsonrpc::btcd_blockhash(
@@ -725,6 +768,23 @@ impl Node for Esplora {
                     res.as_str()?
                 ))));
             }
+        }
+    }
+
+    async fn block(&self, hash: &BlockHash) -> Result<Vec<u8>, FetchError> {
+        let url = format!("{}/block/{}/raw", self.api_url, hash);
+
+        let res = minreq::get(url.clone()).with_timeout(8).send()?;
+
+        match res.status_code {
+            200 => Ok(res.as_bytes().to_vec()),
+            _ => Err(FetchError::EsploraREST(EsploraRESTError::Http(format!(
+                "HTTP request to {} failed: {} {}: {}",
+                url,
+                res.status_code,
+                res.reason_phrase,
+                res.as_str()?
+            )))),
         }
     }
 
@@ -969,6 +1029,13 @@ impl Node for Electrum {
             "Could not fetch coinbase from non-active chain. Not supported by Electrum."
                 .to_string(),
         ));
+    }
+
+    async fn block(&self, _hash: &BlockHash) -> Result<Vec<u8>, FetchError> {
+        // The Electrum protocol has no way to fetch a full block by its hash.
+        Err(FetchError::DataError(
+            "Fetching full blocks by hash is not supported by Electrum.".to_string(),
+        ))
     }
 
     async fn batch_header_fetch(

--- a/src/types.rs
+++ b/src/types.rs
@@ -22,6 +22,16 @@ pub struct Cache {
     pub header_infos_json: Vec<HeaderInfoJson>,
     pub node_data: NodeData,
     pub forks: Vec<Fork>,
+    /// The (up to `MAX_STALE_BLOCKS`) most recent stale blocks we know about.
+    /// A stale block is any block that is not part of the active chain, including
+    /// intermediate (non-tip) blocks of a stale branch.
+    pub stale_blocks: Vec<StaleBlockJson>,
+    /// In-memory cache of full (raw, consensus-serialized) stale blocks, keyed by
+    /// block hash. `Some(bytes)` is a block we fetched from a node; `None` means
+    /// we asked every node and none had it, so we don't retry (a restart clears
+    /// this and retries). Bounded to the blocks currently in `stale_blocks`
+    /// (<= `MAX_STALE_BLOCKS`); entries are pruned as blocks leave that list.
+    pub block_cache: HashMap<BlockHash, Option<Vec<u8>>>,
     /// Since strip_tree and identifying miners runs in parallel,
     /// the strip_tree result might not contain a miner yet. Keeping
     /// recent miners here and use + manage them when updating the cache.
@@ -120,6 +130,31 @@ pub struct InfoJsonResponse {
 pub struct DataJsonResponse {
     pub header_infos: Vec<HeaderInfoJson>,
     pub nodes: Vec<NodeDataJson>,
+}
+
+/// A stale block: a block that is not part of the active chain. This includes
+/// stale tips as well as intermediate (non-tip) blocks of a stale branch.
+#[derive(Debug, Eq, PartialEq, Clone, Serialize)]
+pub struct StaleBlockJson {
+    pub height: u64,
+    pub hash: String,
+    /// The 80-byte block header, hex-encoded.
+    pub header: String,
+}
+
+impl StaleBlockJson {
+    pub fn new(hi: &HeaderInfo) -> Self {
+        StaleBlockJson {
+            height: hi.height,
+            hash: hi.header.block_hash().to_string(),
+            header: corepc_client::bitcoin::consensus::encode::serialize_hex(&hi.header),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct StaleBlocksJsonResponse {
+    pub stale_blocks: Vec<StaleBlockJson>,
 }
 
 #[derive(Serialize, Clone, Eq, Hash, PartialEq, Debug)]

--- a/www/js/blocktree.js
+++ b/www/js/blocktree.js
@@ -631,6 +631,19 @@ function onBlockClick(c, d) {
     })
   }
 
+  // The full block can only be fetched (via the API) for stale blocks: those
+  // that are a tip on some node but not the active chain. The active tip and
+  // ghost "mining" blocks are not served, so we don't offer a link for them.
+  let is_stale = Array.isArray(d.data.data.status)
+    && !d.data.data.status.some(s => s.status == "active");
+  // The `download` attribute renames the fetched file to `<height>-<hash>.<ext>`.
+  let block_basename = `${d.data.data.height}-${d.data.data.hash}`;
+  let block_url = `api/${state_selected_network_id}/block/${d.data.data.hash}`;
+  let download = is_stale
+    ? `<a href="${block_url}/hex" download="${block_basename}.hex">hex</a> `
+      + `<a href="${block_url}/bin" download="${block_basename}.bin">binary</a></span></div>`
+    : "";
+
   let cardWrapper = cardHolder.append("foreignObject")
     .attr("height", "20")
     .attr("width", "600")
@@ -661,6 +674,7 @@ function onBlockClick(c, d) {
                   <span class="col-2">bits</span><span class="col-4 font-monospace">0x${d.data.data.bits.toString(16)}</span>
                   <span class="col-2">difficulty</span><span class="col-4 font-monospace">${d.data.data.difficulty_int}</span>
                   ${ d.data.data.miner != "" ? '<span class="col-2">miner</span><span class="col-4 font-monospace">' + d.data.data.miner + '</span>' : '' }
+                  ${ is_stale ? '<span class="col-2">download</span><span class="col-4">' + download + '</span>' : "" }
                 </div>
                 <div class="row"><span class="col">${status_text}</span></div>
               </div>


### PR DESCRIPTION
Two new API endpoints are added to the fork-observer backend:

- `/api/<network>/stale.json`: Lists the most recent stale headers the fork-observer instance knows about. Includes height, hash, header.
- `/api/<network>/block/<hash>/{bin/hex}`: Returns the raw block as binary or hex for stale blocks. Doesn't return for non-stale blocks.

These allow us to fetch this information for e.g. the bitcoin-data/stale-blocks dataset.