### PR TITLE
Support for friendly network URLs

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -41,6 +41,10 @@ footer_html = """
 id = 1
 name = "Mainnet"
 description = "An example mainnet node."
+# Optional URL-friendly identifier used for friendly URLs like /mainnet and
+# ?network=mainnet. When omitted it is derived from the name (here: "mainnet").
+# Slugs must be unique across networks.
+# slug = "mainnet"
 min_fork_height = 0
 max_interesting_heights = 100
     [networks.pool_identification]

--- a/src/api.rs
+++ b/src/api.rs
@@ -93,6 +93,17 @@ pub fn build_routes(
         .and(with_networks(network_infos.to_vec()))
         .and_then(networks_response);
 
+    // Friendly network URLs: `/testnet4` redirects to `/?network=testnet4`,
+    // which the frontend then resolves. Unknown slugs are rejected so they fall
+    // through to a 404.
+    let slug_redirect = warp::get()
+        .and(warp::path::param::<String>())
+        .and(warp::path::end())
+        .and(with_slugs(
+            network_infos.iter().map(|n| n.slug.clone()).collect(),
+        ))
+        .and_then(slug_redirect_response);
+
     let change_sse = warp::path!("api" / "changes")
         .and(warp::get())
         .map(move || {
@@ -123,6 +134,7 @@ pub fn build_routes(
         .or(lagging_nodes_rss)
         .or(unreachable_nodes_rss)
         .or(invalid_blocks_rss)
+        .or(slug_redirect)
 }
 
 pub async fn info_response(footer: String) -> Result<impl warp::Reply, Infallible> {
@@ -290,6 +302,29 @@ fn block_not_available(block_hash: BlockHash) -> warp::http::Response<Vec<u8>> {
         .unwrap()
 }
 
+/// Redirects a friendly network URL (`/<slug>`) to the query-parameter form the
+/// frontend understands (`?network=<slug>`). Unknown slugs are rejected so warp
+/// continues matching and eventually returns a 404.
+///
+/// The `Location` is a relative reference (`./?network=<slug>`) so it resolves
+/// against the request's directory. This keeps the redirect correct both when
+/// the app is served from the site root and when it is mounted under a subpath
+/// (e.g. `example.com/forks/`), matching the relative URLs the frontend uses.
+pub async fn slug_redirect_response(
+    slug: String,
+    slugs: Vec<String>,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    if slugs.iter().any(|s| *s == slug) {
+        Ok(warp::http::Response::builder()
+            .status(warp::http::StatusCode::FOUND)
+            .header("location", format!("./?network={}", slug))
+            .body(Vec::new())
+            .unwrap())
+    } else {
+        Err(warp::reject::not_found())
+    }
+}
+
 pub async fn networks_response(
     network_infos: Vec<NetworkJson>,
 ) -> Result<impl warp::Reply, Infallible> {
@@ -322,6 +357,12 @@ pub fn with_config_networks(
     networks: Vec<Network>,
 ) -> impl Filter<Extract = (Vec<Network>,), Error = Infallible> + Clone {
     warp::any().map(move || networks.clone())
+}
+
+pub fn with_slugs(
+    slugs: Vec<String>,
+) -> impl Filter<Extract = (Vec<String>,), Error = Infallible> + Clone {
+    warp::any().map(move || slugs.clone())
 }
 
 #[cfg(test)]
@@ -360,6 +401,7 @@ mod tests {
             id,
             description: String::new(),
             name: format!("net{}", id),
+            slug: format!("net{}", id),
             min_fork_height: 0,
             max_interesting_heights: 100,
             nodes,
@@ -476,6 +518,37 @@ mod tests {
         let config = test_config(networks);
         let (cache_changed_tx, _rx) = tokio::sync::broadcast::channel(16);
         build_routes(&network_infos, &config, &caches, cache_changed_tx)
+    }
+
+    #[tokio::test]
+    async fn known_slug_redirects_to_query_param() {
+        // make_network(0, ..) has slug "net0".
+        let route = routes(caches_with_stale(0, vec![]), vec![make_network(0, vec![])]);
+        let resp = warp::test::request().path("/net0").reply(&route).await;
+        assert_eq!(resp.status(), 302);
+        assert_eq!(resp.headers().get("location").unwrap(), "./?network=net0");
+    }
+
+    #[tokio::test]
+    async fn unknown_slug_returns_404() {
+        let route = routes(caches_with_stale(0, vec![]), vec![make_network(0, vec![])]);
+        let resp = warp::test::request()
+            .path("/does-not-exist")
+            .reply(&route)
+            .await;
+        assert_eq!(resp.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn networks_json_exposes_slug() {
+        let route = routes(caches_with_stale(0, vec![]), vec![make_network(0, vec![])]);
+        let resp = warp::test::request()
+            .path("/api/networks.json")
+            .reply(&route)
+            .await;
+        assert_eq!(resp.status(), 200);
+        let v: serde_json::Value = serde_json::from_slice(resp.body()).unwrap();
+        assert_eq!(v["networks"][0]["slug"], "net0");
     }
 
     #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,10 @@ struct TomlNetwork {
     id: u32,
     name: String,
     description: String,
+    /// An optional URL-friendly identifier for the network (e.g. `testnet4`).
+    /// When omitted it is derived from the name. Used for friendly URLs like
+    /// `/testnet4` and `?network=testnet4`.
+    slug: Option<String>,
     min_fork_height: u64,
     max_interesting_heights: usize,
     nodes: Vec<TomlNode>,
@@ -84,6 +88,7 @@ pub struct Network {
     pub id: u32,
     pub description: String,
     pub name: String,
+    pub slug: String,
     pub min_fork_height: u64,
     pub max_interesting_heights: usize,
     pub nodes: Vec<BoxedSyncSendNode>,
@@ -204,6 +209,7 @@ fn parse_config(config_str: &str) -> Result<Config, ConfigError> {
 
     let mut networks: Vec<Network> = vec![];
     let mut network_ids: Vec<u32> = vec![];
+    let mut network_slugs: Vec<String> = vec![];
     for toml_network in toml_config.networks.iter() {
         let mut nodes: Vec<BoxedSyncSendNode> = vec![];
         let mut node_ids: Vec<u32> = vec![];
@@ -230,16 +236,23 @@ fn parse_config(config_str: &str) -> Result<Config, ConfigError> {
         }
         match parse_toml_network(toml_network, nodes) {
             Ok(network) => {
-                if !network_ids.contains(&network.id) {
-                    network_ids.push(network.id);
-                    networks.push(network);
-                } else {
+                if network_ids.contains(&network.id) {
                     error!(
                         "Duplicate network id {}: The network {} could not be loaded.",
                         network.id, network.name
                     );
                     return Err(ConfigError::DuplicateNetworkId);
                 }
+                if network_slugs.contains(&network.slug) {
+                    error!(
+                        "Duplicate network slug '{}': The network {} could not be loaded.",
+                        network.slug, network.name
+                    );
+                    return Err(ConfigError::DuplicateNetworkSlug);
+                }
+                network_ids.push(network.id);
+                network_slugs.push(network.slug.clone());
+                networks.push(network);
             }
             Err(e) => {
                 error!(
@@ -270,15 +283,44 @@ fn parse_toml_network(
     toml_network: &TomlNetwork,
     nodes: Vec<BoxedSyncSendNode>,
 ) -> Result<Network, ConfigError> {
+    // Use the configured slug if present, otherwise derive one from the name.
+    // Either way we slugify to guarantee a URL-safe result. As a last resort
+    // (e.g. an empty or purely-symbolic name) we fall back to the network id.
+    let mut slug = slugify(toml_network.slug.as_deref().unwrap_or(&toml_network.name));
+    if slug.is_empty() {
+        slug = toml_network.id.to_string();
+    }
+
     Ok(Network {
         id: toml_network.id,
         name: toml_network.name.clone(),
+        slug,
         description: toml_network.description.clone(),
         min_fork_height: toml_network.min_fork_height,
         max_interesting_heights: toml_network.max_interesting_heights,
         nodes,
         pool_identification: toml_network.pool_identification.clone().unwrap_or_default(),
     })
+}
+
+/// Turns an arbitrary string into a URL-friendly slug: ASCII alphanumerics are
+/// lowercased and any run of other characters becomes a single `-`. Leading and
+/// trailing dashes are trimmed (e.g. `"Testnet 4!"` becomes `"testnet-4"`).
+fn slugify(s: &str) -> String {
+    let mut slug = String::new();
+    let mut pending_dash = false;
+    for c in s.chars() {
+        if c.is_ascii_alphanumeric() {
+            if pending_dash && !slug.is_empty() {
+                slug.push('-');
+            }
+            pending_dash = false;
+            slug.push(c.to_ascii_lowercase());
+        } else {
+            pending_dash = true;
+        }
+    }
+    slug
 }
 
 /// Ensures the host carries a URL scheme. For backwards compatibility we default
@@ -415,6 +457,132 @@ mod tests {
         )
         .expect("node with use_waitfornewblock should parse");
         assert_eq!(node.use_waitfornewblock, Some(false));
+    }
+
+    #[test]
+    fn slugify_test() {
+        assert_eq!(slugify("Testnet4"), "testnet4");
+        assert_eq!(slugify("Mainnet"), "mainnet");
+        assert_eq!(slugify("Testnet 4!"), "testnet-4");
+        assert_eq!(slugify("  Signet  "), "signet");
+        assert_eq!(slugify("a__b--c"), "a-b-c");
+        assert_eq!(slugify("!!!"), "");
+    }
+
+    #[test]
+    fn slug_derived_from_name_when_absent() {
+        let config = parse_config(
+            r#"
+            database_path = ""
+            www_path = "./www"
+            query_interval = 15
+            address = "127.0.0.1:2323"
+            rss_base_url = ""
+            footer_html = ""
+
+            [[networks]]
+            id = 1
+            name = "Testnet 4"
+            description = ""
+            min_fork_height = 0
+            max_interesting_heights = 0
+
+                [[networks.nodes]]
+                id = 0
+                name = "Node A"
+                description = ""
+                rpc_host = "127.0.0.1"
+                rpc_port = 0
+                rpc_user = ""
+                rpc_password = ""
+        "#,
+        )
+        .expect("config should parse");
+        assert_eq!(config.networks[0].slug, "testnet-4");
+    }
+
+    #[test]
+    fn explicit_slug_is_used() {
+        let config = parse_config(
+            r#"
+            database_path = ""
+            www_path = "./www"
+            query_interval = 15
+            address = "127.0.0.1:2323"
+            rss_base_url = ""
+            footer_html = ""
+
+            [[networks]]
+            id = 1
+            name = "Testnet 4"
+            slug = "tn4"
+            description = ""
+            min_fork_height = 0
+            max_interesting_heights = 0
+
+                [[networks.nodes]]
+                id = 0
+                name = "Node A"
+                description = ""
+                rpc_host = "127.0.0.1"
+                rpc_port = 0
+                rpc_user = ""
+                rpc_password = ""
+        "#,
+        )
+        .expect("config should parse");
+        assert_eq!(config.networks[0].slug, "tn4");
+    }
+
+    #[test]
+    fn error_on_duplicate_network_slug_test() {
+        // Two different names that slugify to the same slug.
+        match parse_config(
+            r#"
+            database_path = ""
+            www_path = "./www"
+            query_interval = 15
+            address = "127.0.0.1:2323"
+            rss_base_url = ""
+            footer_html = ""
+
+            [[networks]]
+            id = 1
+            name = "Testnet 4"
+            description = ""
+            min_fork_height = 0
+            max_interesting_heights = 0
+
+                [[networks.nodes]]
+                id = 0
+                name = "Node A"
+                description = ""
+                rpc_host = "127.0.0.1"
+                rpc_port = 0
+                rpc_user = ""
+                rpc_password = ""
+            [[networks]]
+            id = 2
+            name = "testnet-4"
+            description = ""
+            min_fork_height = 0
+            max_interesting_heights = 0
+
+                [[networks.nodes]]
+                id = 0
+                name = "Node B"
+                description = ""
+                rpc_host = "127.0.0.1"
+                rpc_port = 0
+                rpc_user = ""
+                rpc_password = ""
+        "#,
+        ) {
+            Err(ConfigError::DuplicateNetworkSlug) => {
+                // test OK, as we expect this to error
+            }
+            _ => panic!("expected DuplicateNetworkSlug error"),
+        }
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -124,6 +124,7 @@ pub enum ConfigError {
     UnknownImplementation,
     DuplicateNodeId,
     DuplicateNetworkId,
+    DuplicateNetworkSlug,
     TomlError(toml::de::Error),
     ReadError(io::Error),
     AddrError(AddrParseError),
@@ -139,6 +140,7 @@ impl fmt::Display for ConfigError {
             ConfigError::UnknownImplementation => write!(f, "the node implementation defined in the config is not supported"),
             ConfigError::DuplicateNodeId => write!(f, "a node id has been used multiple times in the same network"),
             ConfigError::DuplicateNetworkId => write!(f, "a network id has been used multiple times"),
+            ConfigError::DuplicateNetworkSlug => write!(f, "a network slug has been used multiple times (slugs must be unique; set an explicit `slug` for one of the networks)"),
             ConfigError::TomlError(e) => write!(f, "the TOML in the configuration file could not be parsed: {}", e),
             ConfigError::ReadError(e) => write!(f, "the configuration file could not be read: {}", e),
             ConfigError::AddrError(e) => write!(f, "the address could not be parsed: {}", e),
@@ -159,6 +161,7 @@ impl error::Error for ConfigError {
             ConfigError::AddrError(ref e) => Some(e),
             ConfigError::DuplicateNodeId => None,
             ConfigError::DuplicateNetworkId => None,
+            ConfigError::DuplicateNetworkSlug => None,
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -61,6 +61,7 @@ impl HeaderInfo {
 pub struct NetworkJson {
     pub id: u32,
     pub name: String,
+    pub slug: String,
     pub description: String,
 }
 
@@ -69,6 +70,7 @@ impl NetworkJson {
         NetworkJson {
             id: network.id,
             name: network.name.clone(),
+            slug: network.slug.clone(),
             description: network.description.clone(),
         }
     }

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -61,6 +61,12 @@ function update_network() {
   rssInvalidBlocks.node().href = `rss/${current_network.id}/invalid.xml`
   rssLaggingNodes.node().href = `rss/${current_network.id}/lagging.xml`
   rssUnreachableNodes.node().href = `rss/${current_network.id}/unreachable.xml`
+
+  // Keep the URL in sync with the selected network, using the friendly slug, so
+  // it can be bookmarked and shared (e.g. ?network=testnet4).
+  let url = new URL(window.location)
+  url.searchParams.set(SEARCH_PARAM_NETWORK, current_network.slug)
+  window.history.replaceState({}, "", url)
 }
 
 function set_initial_network() {
@@ -69,9 +75,12 @@ function set_initial_network() {
   let searchParams = new URLSearchParams(url.search);
   let searchParamNetwork = searchParams.get(SEARCH_PARAM_NETWORK)
 
-  if (searchParamNetwork != null && state_networks.filter(x => x.id == searchParamNetwork).length > 0) {
+  // Match the URL parameter against the network slug or, for backwards
+  // compatibility, the numeric network id.
+  let matched = state_networks.find(x => x.slug == searchParamNetwork || x.id == searchParamNetwork)
+  if (searchParamNetwork != null && matched != undefined) {
     console.debug("Setting network to", searchParamNetwork, "based on the URL search parameter", SEARCH_PARAM_NETWORK)
-    state_selected_network_id = searchParamNetwork
+    state_selected_network_id = matched.id
   } else {
     console.debug("Setting network to first network:", state_networks[0].id);
     state_selected_network_id = state_networks[0].id


### PR DESCRIPTION
This introduces an optional `slug`. If unset, one is generated.

For a network with id=4 named "Testnet4" and slug "testnet4" we now support:

- https://example.com/?network=4
- https://example.com/?network=testnet4
- https://example.com/testnet4

and we'll set the URL when switching networks.

This closes https://github.com/0xB10C/fork-observer/issues/49