### PR TITLE
add: support for mempool as a backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,21 +60,64 @@ rpcwhitelist=forkobserver:getchaintips,getblockheader,getblockhash,getblock
 
 ## Connecting to an Esplora REST API
 
-Block explorers like blockstream.info and mempool.space are based on [esplora].
-While they don't offer a `getchaintips`-like API endpoint, it can be useful to
-know which blocks these explores consider to be the tip. A esplora backend can,
-for example, be configured using the following "node" configuration.
+Block explorers like blockstream.info are based on [esplora]. While they don't
+offer a `getchaintips`-like API endpoint, it can be useful to know which block
+these explorers consider to be the tip. A esplora backend can, for example, be
+configured using the following "node" configuration.
+
+**Limitation:** Esplora never reports stale/fork blocks, only the active tip.
+Only add it to a network that already has at least one Bitcoin Core (or btcd)
+node.
 
 ```toml
 [[networks.nodes]]
 id = 2
-name = "mempool.space"
-description = "mempool.space REST API"
-rpc_host = "https://mempool.space/api"
+name = "blockstream.info"
+description = "blockstream.info REST API"
+rpc_host = "https://blockstream.info/api"
 implementation = "esplora"
 ```
 
 [esplora]: https://github.com/Blockstream/esplora
+
+
+## Connecting to mempool.space
+
+mempool.space additionally exposes a `getchaintips`-like `/api/v1/chain-tips`
+endpoint, so a `mempoolspace` backend reports stale/fork chain tips as well as
+the active one (unlike the generic `esplora` backend above, which can only
+report the current active tip). Note that this endpoint is not yet stabilized
+by the mempool.space project.
+
+```toml
+[[networks.nodes]]
+id = 4
+name = "mempool.space"
+description = "mempool.space public API"
+rpc_host = "https://mempool.space/api"
+implementation = "mempoolspace"
+```
+
+Use `rpc_host = "https://mempool.space/testnet/api"` (or `/signet/api`) to
+connect to a different network.
+
+**Limitations:** fork branches are only fetched for the tips
+`/api/v1/chain-tips` currently reports, and mempool.space serves no block data
+for the `headers-only` tips among them, so this backend can't reconstruct fork
+history on its own. Only add it to a network that already has at least one
+Bitcoin Core (or btcd) node.
+
+> [!NOTE]
+> Loading the full header tree from a mempool.space instance is neither
+> supported nor recommended. This is a public, rate-limited API with no bulk
+> header endpoint, so headers are fetched one at a time.
+>
+> In the recommended setup this costs almost nothing: all nodes of a network
+> share one header tree, so the Bitcoin Core node supplies the active chain and
+> this backend stops at the first header it already knows - normally after a
+> single request per new block. Backfilling a long stretch of history from
+> mempool.space alone, on the other hand, is slow and will run into rate limits,
+> so keep `min_fork_height` close to the current tip.
 
 
 ## Connecting to an Electrum server
@@ -94,6 +137,9 @@ rpc_port = 50002
 implementation = "electrum"
 ```
 
+**Limitation:** Electrum has no protocol call for stale/fork block headers, so
+this backend never reports forks, only the active tip. Only add it to a
+network that already has at least one Bitcoin Core (or btcd) node.
 
 ## Countdown to a block height
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -81,6 +81,8 @@ max_interesting_heights = 100
     rpc_user = "forkobserver"
     rpc_password = ""
 
+    # Electrum never reports stale/fork blocks (see README) - only add it to a
+    # network that already has at least one Bitcoin Core (or btcd) node.
     [[networks.nodes]]
     id = 3
     name = "Electrum Emzy"
@@ -88,6 +90,18 @@ max_interesting_heights = 100
     rpc_host = "ssl://electrum.emzy.de"
     rpc_port = 50002
     implementation = "electrum"
+
+    # Reports fork tips, but can't reconstruct fork history on its own (see
+    # README) - only add it to a network that already has at least one Bitcoin
+    # Core (or btcd) node. Keep query_interval conservative and min_fork_height
+    # close to the tip: this is a public, rate-limited API.
+    [[networks.nodes]]
+    id = 4
+    name = "mempool.space"
+    description = "mempool.space public API"
+    # For testnet, use "https://mempool.space/testnet/api" instead.
+    rpc_host = "https://mempool.space/api"
+    implementation = "mempoolspace"
 
 [[networks]]
 id = 0xFFFFFFFE

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use crate::error::ConfigError;
-use crate::node::{BitcoinCoreNode, BtcdNode, Electrum, Esplora, Node, NodeInfo};
+use crate::node::{BitcoinCoreNode, BtcdNode, Electrum, Esplora, MempoolSpace, Node, NodeInfo};
 use corepc_client::bitcoin::Network as BitcoinNetwork;
 use corepc_client::client_sync::Auth;
 use log::{error, info};
@@ -160,6 +160,9 @@ pub enum Backend {
     Esplora,
     /// An Electrum server as backend.
     Electrum,
+    /// A mempool.space instance, additionally exposing stale chain tips via
+    /// its `/api/v1/chain-tips` endpoint.
+    MempoolSpace,
 }
 
 impl FromStr for Backend {
@@ -173,6 +176,9 @@ impl FromStr for Backend {
             "btcd" => Ok(Backend::Btcd),
             "esplora" => Ok(Backend::Esplora),
             "electrum" => Ok(Backend::Electrum),
+            "mempoolspace" => Ok(Backend::MempoolSpace),
+            "mempool.space" => Ok(Backend::MempoolSpace),
+            "mempool" => Ok(Backend::MempoolSpace),
             _ => Err(ConfigError::UnknownImplementation),
         }
     }
@@ -185,6 +191,7 @@ impl fmt::Display for Backend {
             Backend::Btcd => write!(f, "btcd"),
             Backend::Esplora => write!(f, "esplora"),
             Backend::Electrum => write!(f, "electrum"),
+            Backend::MempoolSpace => write!(f, "mempool.space"),
         }
     }
 }
@@ -393,6 +400,7 @@ fn parse_toml_node(toml_node: &TomlNode) -> Result<BoxedSyncSendNode, ConfigErro
             ))
         }
         Backend::Esplora => Arc::new(Esplora::new(node_info, toml_node.rpc_host.clone())),
+        Backend::MempoolSpace => Arc::new(MempoolSpace::new(node_info, toml_node.rpc_host.clone())),
         Backend::Electrum => {
             let url = format!(
                 "{}:{}",
@@ -798,6 +806,57 @@ mod tests {
             Err(e) => {
                 panic!("Esplora backend config invalid: {}", e);
             }
+        }
+    }
+
+    #[test]
+    fn mempool_space_backend_test() {
+        match parse_config(
+            r#"
+            database_path = ""
+            www_path = "./www"
+            query_interval = 15
+            address = "127.0.0.1:2323"
+            rss_base_url = ""
+            footer_html = ""
+
+            [[networks]]
+            id = 1
+            name = ""
+            description = ""
+            min_fork_height = 0
+            max_interesting_heights = 0
+
+                [[networks.nodes]]
+                id = 5
+                name = "mempool.space"
+                description = "mempool.space public API"
+                rpc_host = "https://mempool.space/api"
+                implementation = "mempoolspace"
+        "#,
+        ) {
+            Ok(config) => {
+                let network = &config.networks[0];
+                let node: &BoxedSyncSendNode = &network.nodes[0];
+                let node_info = node.info();
+                assert_eq!(node_info.name, "mempool.space");
+                assert_eq!(node_info.id, 5);
+                assert_eq!(node_info.implementation, "mempool.space");
+            }
+            Err(e) => {
+                panic!("mempool.space backend config invalid: {}", e);
+            }
+        }
+    }
+
+    #[test]
+    fn backend_from_str_accepts_mempool_space_aliases() {
+        for alias in ["mempoolspace", "mempool.space", "mempool", "MempoolSpace"] {
+            assert!(
+                matches!(alias.parse::<Backend>(), Ok(Backend::MempoolSpace)),
+                "expected '{}' to parse as Backend::MempoolSpace",
+                alias
+            );
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -10,6 +10,7 @@ use electrum_client::{
     Client as ElectrumClient, ConfigBuilder as ElectrumClientConfigBuilder, ElectrumApi,
 };
 use log::{debug, error};
+use serde::Deserialize;
 use std::cmp::max;
 use std::fmt;
 use std::str::FromStr;
@@ -34,6 +35,11 @@ pub struct Capabilities {
     /// active chain.
     header_fetch_type: HeaderFetchType,
     batch_header_fetch: bool,
+    /// Set for data sources that report non-active tips they can't serve headers
+    /// for (mempool.space, for example, 404s on `headers-only` tips). A failing
+    /// header fetch then skips the rest of that branch instead of failing the
+    /// whole update.
+    partial_nonactive_headers: bool,
 }
 
 #[async_trait]
@@ -227,7 +233,7 @@ pub trait Node: Sync {
             for i in 0..=inactive_tip.branchlen {
                 {
                     let tree_locked = tree.lock().await;
-                    if tree_locked.1.contains_key(&inactive_tip.block_hash()) {
+                    if tree_locked.1.contains_key(&next_header) {
                         break;
                     }
                 }
@@ -238,7 +244,17 @@ pub trait Node: Sync {
                     next_header, height
                 );
 
-                let header = self.block_header_hash(&next_header).await?;
+                let header = match self.block_header_hash(&next_header).await {
+                    Ok(header) => header,
+                    Err(e) if self.capabilities().partial_nonactive_headers => {
+                        debug!(
+                            "could not fetch non-active-chain header hash={} height={} of tip {}: {} - skipping the rest of this branch",
+                            next_header, height, inactive_tip.hash, e
+                        );
+                        break;
+                    }
+                    Err(e) => return Err(e),
+                };
                 new_headers.push(HeaderInfo {
                     height,
                     header,
@@ -320,6 +336,7 @@ impl Node for BitcoinCoreNode {
         Capabilities {
             header_fetch_type: HeaderFetchType::Hash,
             batch_header_fetch: self.use_rest,
+            partial_nonactive_headers: false,
         }
     }
 
@@ -540,6 +557,7 @@ impl Node for BtcdNode {
         Capabilities {
             header_fetch_type: HeaderFetchType::Hash,
             batch_header_fetch: false,
+            partial_nonactive_headers: false,
         }
     }
 
@@ -658,6 +676,7 @@ impl Node for Esplora {
         Capabilities {
             header_fetch_type: HeaderFetchType::Hash,
             batch_header_fetch: false,
+            partial_nonactive_headers: false,
         }
     }
 
@@ -876,6 +895,167 @@ impl Node for Esplora {
     }
 }
 
+/// The subset of mempool.space's `/api/v1/block/{hash}` JSON we use:
+/// `extras.header` is the consensus-serialized block header in hex.
+#[derive(Deserialize)]
+struct MempoolSpaceBlock {
+    extras: MempoolSpaceBlockExtras,
+}
+
+#[derive(Deserialize)]
+struct MempoolSpaceBlockExtras {
+    header: String,
+}
+
+#[derive(Deserialize)]
+struct MempoolSpaceBackendInfo {
+    version: String,
+}
+
+/// Deserializes the header in `block.extras` and checks that it hashes to `hash`,
+/// the hash the caller asked for. mempool.space's chain-tips API isn't stabilized
+/// yet, so this guards against schema drift silently attributing a header to the
+/// wrong block.
+fn header_from_mempool_space_block(
+    hash: &BlockHash,
+    block: &MempoolSpaceBlock,
+) -> Result<Header, FetchError> {
+    let header_bytes = Vec::from_hex(&block.extras.header).map_err(|e| {
+        FetchError::DataError(format!(
+            "Can't hex decode block header '{}' for block {}: {}",
+            block.extras.header, hash, e
+        ))
+    })?;
+    let header: Header =
+        corepc_client::bitcoin::consensus::deserialize(&header_bytes).map_err(|e| {
+            FetchError::DataError(format!(
+                "Can't deserialize block header '{}' for block {}: {}",
+                block.extras.header, hash, e
+            ))
+        })?;
+
+    if header.block_hash() != *hash {
+        return Err(FetchError::DataError(format!(
+            "mempool.space block JSON for {} produced a header with a different hash ({})",
+            hash,
+            header.block_hash()
+        )));
+    }
+
+    Ok(header)
+}
+
+/// mempool.space is Esplora-API-compatible for active-chain blocks, but additionally
+/// exposes a getchaintips-like `/api/v1/chain-tips` endpoint. This is used to fetch
+/// stale/fork chain tips, which plain Esplora instances can't report. Fork-branch
+/// headers are not available through the Esplora header endpoint (it 404s for
+/// blocks off the active chain), so they are read from `/api/v1/block/{hash}`
+/// instead.
+pub struct MempoolSpace {
+    info: NodeInfo,
+    esplora: Esplora,
+}
+
+impl MempoolSpace {
+    pub fn new(info: NodeInfo, api_url: String) -> Self {
+        MempoolSpace {
+            esplora: Esplora::new(info.clone(), api_url),
+            info,
+        }
+    }
+
+    /// GETs `{api_url}/v1{path}` and deserializes the JSON response body.
+    async fn get_json<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T, FetchError> {
+        let url = format!("{}/v1{}", self.rpc_url(), path);
+        debug!("mempool.space: GET {}", url);
+
+        let res = minreq::get(url.as_str()).with_timeout(8).send()?;
+        if res.status_code != 200 {
+            return Err(FetchError::EsploraREST(EsploraRESTError::Http(format!(
+                "HTTP request to {} failed: {} {}",
+                url, res.status_code, res.reason_phrase,
+            ))));
+        }
+
+        res.json().map_err(|e| {
+            FetchError::DataError(format!("Can't parse JSON response from {}: {}", url, e))
+        })
+    }
+}
+
+#[async_trait]
+impl Node for MempoolSpace {
+    fn info(&self) -> NodeInfo {
+        self.info.clone()
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            header_fetch_type: HeaderFetchType::Hash,
+            // mempool.space has no bulk header endpoint - the best it offers is
+            // 15 blocks per request, so a batch fetch of `new_active_headers`'
+            // 2000 block window would cost ~134 requests every time the tip
+            // moves. Fetching header by header instead lets `new_active_headers`
+            // stop at the first header already in the tree, which is normally
+            // the very first one: this backend is meant to run alongside a
+            // Bitcoin Core node that shares the network's tree and has already
+            // supplied the active chain.
+            batch_header_fetch: false,
+            // mempool.space 404s on `headers-only` tips it reports itself.
+            partial_nonactive_headers: true,
+        }
+    }
+
+    fn rpc_url(&self) -> String {
+        self.esplora.rpc_url()
+    }
+
+    async fn version(&self) -> Result<String, FetchError> {
+        let info: MempoolSpaceBackendInfo = self.get_json("/backend-info").await?;
+        Ok(info.version)
+    }
+
+    async fn block_header_hash(&self, hash: &BlockHash) -> Result<Header, FetchError> {
+        let block: MempoolSpaceBlock = self.get_json(&format!("/block/{}", hash)).await?;
+        header_from_mempool_space_block(hash, &block)
+    }
+
+    async fn block_header_height(&self, _: u64) -> Result<Header, FetchError> {
+        assert_eq!(self.capabilities().header_fetch_type, HeaderFetchType::Hash);
+        Err(FetchError::DataError(
+            "fetch by block height not implemented".to_string(),
+        ))
+    }
+
+    async fn block_hash(&self, height: u64) -> Result<BlockHash, FetchError> {
+        self.esplora.block_hash(height).await
+    }
+
+    async fn coinbase(&self, hash: &BlockHash, height: u64) -> Result<Transaction, FetchError> {
+        self.esplora.coinbase(hash, height).await
+    }
+
+    async fn block(&self, hash: &BlockHash) -> Result<Vec<u8>, FetchError> {
+        self.esplora.block(hash).await
+    }
+
+    async fn batch_header_fetch(
+        &self,
+        _start_hash: BlockHash,
+        _start_height: u64,
+        _count: u64,
+    ) -> Result<Vec<Header>, FetchError> {
+        assert!(self.capabilities().batch_header_fetch);
+        Err(FetchError::DataError(
+            "batch header fetch not implemented".to_string(),
+        ))
+    }
+
+    async fn tips(&self) -> Result<Vec<ChainTip>, FetchError> {
+        self.get_json("/chain-tips").await
+    }
+}
+
 pub struct Electrum {
     info: NodeInfo,
     url: String,
@@ -935,6 +1115,7 @@ impl Node for Electrum {
         Capabilities {
             header_fetch_type: HeaderFetchType::Height,
             batch_header_fetch: true,
+            partial_nonactive_headers: false,
         }
     }
 
@@ -1289,5 +1470,78 @@ mod bitcoin_core_tests {
             start.elapsed() >= timeout,
             "polling fallback should wait out the full timeout"
         );
+    }
+}
+
+#[cfg(test)]
+mod mempool_space_tests {
+    use super::*;
+
+    // A real response (trimmed to the fields we use) from
+    // `https://mempool.space/api/v1/block/00000000000000000001e9c1b31d923680b0472cc3d8e301210dfca4631e2996`,
+    // a `valid-fork` (stale) tip reported by `/api/v1/chain-tips` at the time of writing.
+    const STALE_BLOCK_JSON: &str = r#"{
+        "id": "00000000000000000001e9c1b31d923680b0472cc3d8e301210dfca4631e2996",
+        "height": 951052,
+        "extras": {
+            "header": "00000038610942633517e2cd09edd97db9476d906ae59ea66ab400000000000000000000c65ea6e40547282a7d996633fe4f0484b81a870ea6a3376257180b26124eabd1c9f3146a790f02178ab1690f"
+        }
+    }"#;
+
+    #[test]
+    fn header_from_mempool_space_block_reconstructs_known_header() {
+        let hash =
+            BlockHash::from_str("00000000000000000001e9c1b31d923680b0472cc3d8e301210dfca4631e2996")
+                .unwrap();
+        let block: MempoolSpaceBlock = serde_json::from_str(STALE_BLOCK_JSON).unwrap();
+
+        let header = header_from_mempool_space_block(&hash, &block)
+            .expect("known-good block JSON should reconstruct a valid header");
+
+        assert_eq!(header.block_hash(), hash);
+        assert_eq!(
+            header.prev_blockhash.to_string(),
+            "00000000000000000000b46aa69ee56a906d47b97dd9ed09cde2173563420961"
+        );
+    }
+
+    #[test]
+    fn header_from_mempool_space_block_rejects_hash_mismatch() {
+        // A hash that doesn't match the block content: the reconstructed header
+        // must not silently be attributed to the wrong block.
+        let wrong_hash =
+            BlockHash::from_str("00000000000000000001e9c1b31d923680b0472cc3d8e301210dfca4631eDEAD")
+                .unwrap();
+        let block: MempoolSpaceBlock = serde_json::from_str(STALE_BLOCK_JSON).unwrap();
+
+        let result = header_from_mempool_space_block(&wrong_hash, &block);
+        assert!(result.is_err());
+    }
+
+    // `/api/v1/chain-tips` reports tips in the same shape as Bitcoin Core's
+    // `getchaintips`, so they deserialize straight into `ChainTip`.
+    #[test]
+    fn chain_tips_json_parses() {
+        let json = r#"[
+            {"height":960315,"hash":"00000000000000000000c4dd83a223d8a32c9904c787948fd42c88c30739553a","branchlen":0,"status":"active"},
+            {"height":951052,"hash":"00000000000000000001e9c1b31d923680b0472cc3d8e301210dfca4631e2996","branchlen":1,"status":"valid-fork"},
+            {"height":922047,"hash":"00000000000000000000f05494b5ced664d0553b16d9dc188faa4eea96aa437c","branchlen":1,"status":"headers-only"},
+            {"height":900000,"hash":"00000000000000000000e2ea2b4b3b594a6806d35319b85bc12c418dbbe2b566","branchlen":1,"status":"some-future-status"}
+        ]"#;
+        let tips: Vec<ChainTip> = serde_json::from_str(json).unwrap();
+
+        assert_eq!(tips.len(), 4);
+        assert_eq!(tips[0].status, ChainTipStatus::Active);
+        assert_eq!(tips[1].status, ChainTipStatus::ValidFork);
+        assert_eq!(tips[2].status, ChainTipStatus::HeadersOnly);
+        // A status mempool.space might add later must not fail the whole response.
+        assert_eq!(tips[3].status, ChainTipStatus::Unknown);
+    }
+
+    #[test]
+    fn backend_info_json_parses() {
+        let json = r#"{"hostname":"node208.fra.mempool.space","version":"3.4-dev","gitCommit":"3da515d4f","lightning":false,"backend":"esplora"}"#;
+        let info: MempoolSpaceBackendInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.version, "3.4-dev");
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -246,17 +246,15 @@ pub struct DataChanged {
     pub network_id: u32,
 }
 
+/// Deserialized via `From<String>` so that a status we don't know yet becomes
+/// `Unknown` instead of failing the whole `getchaintips` response.
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(from = "String")]
 pub enum ChainTipStatus {
-    #[serde(rename = "active")]
     Active,
-    #[serde(rename = "invalid")]
     Invalid,
-    #[serde(rename = "valid-fork")]
     ValidFork,
-    #[serde(rename = "headers-only")]
     HeadersOnly,
-    #[serde(rename = "valid-headers")]
     ValidHeaders,
     Unknown,
 }


### PR DESCRIPTION
This fetches from `/api/v1/chain-tip` and the esplora backend.

resolves #111