### PR TITLE
add: per-network height countdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,18 @@ rpc_host = "ssl://electrum.emzy.de"
 rpc_port = 50002
 implementation = "electrum"
 ```
+
+
+## Countdown to a block height
+
+Each network can optionally show a countdown to a specific block height (e.g. a
+halving) in the frontend. At most one countdown per network; when omitted,
+nothing is shown. The five blocks around the target height
+(`height - 2` to `height + 2`) are always kept in the API response once mined,
+regardless of `max_interesting_heights`.
+
+```toml
+[networks.countdown]
+height = 1050000
+label = "Halving"
+```

--- a/config.toml.example
+++ b/config.toml.example
@@ -50,6 +50,11 @@ max_interesting_heights = 100
     [networks.pool_identification]
     enable = true
     network = "Mainnet"
+    # Optional countdown to a specific block height, shown in the frontend
+    # (e.g. a halving). At most one per network; omit this table for none.
+    # [networks.countdown]
+    # height = 1050000
+    # label = "Halving"
 
     [[networks.nodes]]
     id = 0

--- a/src/api.rs
+++ b/src/api.rs
@@ -37,6 +37,7 @@ pub fn build_routes(
     let data_json = warp::get()
         .and(warp::path!("api" / u32 / "data.json"))
         .and(with_caches(caches.clone()))
+        .and(with_config_networks(config.networks.clone()))
         .and_then(data_response);
 
     let stale_json = warp::get()
@@ -141,16 +142,26 @@ pub async fn info_response(footer: String) -> Result<impl warp::Reply, Infallibl
     Ok(warp::reply::json(&InfoJsonResponse { footer }))
 }
 
-pub async fn data_response(network: u32, caches: Caches) -> Result<impl warp::Reply, Infallible> {
+pub async fn data_response(
+    network: u32,
+    caches: Caches,
+    networks: Vec<Network>,
+) -> Result<impl warp::Reply, Infallible> {
+    let countdown = networks
+        .iter()
+        .find(|n| n.id == network)
+        .and_then(|n| n.countdown.clone());
     let caches_locked = caches.lock().await;
     match caches_locked.get(&network) {
         Some(cache) => Ok(warp::reply::json(&DataJsonResponse {
             header_infos: cache.header_infos_json.clone(),
             nodes: cache.node_data.values().cloned().collect(),
+            countdown,
         })),
         None => Ok(warp::reply::json(&DataJsonResponse {
             header_infos: vec![],
             nodes: vec![],
+            countdown,
         })),
     }
 }
@@ -406,6 +417,7 @@ mod tests {
             max_interesting_heights: 100,
             nodes,
             pool_identification: PoolIdentification::default(),
+            countdown: None,
         }
     }
 
@@ -549,6 +561,36 @@ mod tests {
         assert_eq!(resp.status(), 200);
         let v: serde_json::Value = serde_json::from_slice(resp.body()).unwrap();
         assert_eq!(v["networks"][0]["slug"], "net0");
+    }
+
+    #[tokio::test]
+    async fn data_json_exposes_countdown_when_configured() {
+        let mut network = make_network(0, vec![]);
+        network.countdown = Some(crate::config::Countdown {
+            height: 105,
+            label: "Halving".to_string(),
+        });
+        let route = routes(caches_with_stale(0, vec![]), vec![network]);
+        let resp = warp::test::request()
+            .path("/api/0/data.json")
+            .reply(&route)
+            .await;
+        assert_eq!(resp.status(), 200);
+        let v: serde_json::Value = serde_json::from_slice(resp.body()).unwrap();
+        assert_eq!(v["countdown"]["height"], 105);
+        assert_eq!(v["countdown"]["label"], "Halving");
+    }
+
+    #[tokio::test]
+    async fn data_json_omits_countdown_when_not_configured() {
+        let route = routes(caches_with_stale(0, vec![]), vec![make_network(0, vec![])]);
+        let resp = warp::test::request()
+            .path("/api/0/data.json")
+            .reply(&route)
+            .await;
+        assert_eq!(resp.status(), 200);
+        let v: serde_json::Value = serde_json::from_slice(resp.body()).unwrap();
+        assert!(v.get("countdown").is_none());
     }
 
     #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use crate::node::{BitcoinCoreNode, BtcdNode, Electrum, Esplora, Node, NodeInfo};
 use corepc_client::bitcoin::Network as BitcoinNetwork;
 use corepc_client::client_sync::Auth;
 use log::{error, info};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::hash::Hash;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -68,6 +68,14 @@ pub struct PoolIdentification {
     pub network: Option<PoolIdentificationNetwork>,
 }
 
+/// A countdown to a specific block height, shown in the frontend. At most one
+/// per network; when unset for a network, no countdown is shown.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct Countdown {
+    pub height: u64,
+    pub label: String,
+}
+
 #[derive(Debug, Deserialize)]
 struct TomlNetwork {
     id: u32,
@@ -81,6 +89,7 @@ struct TomlNetwork {
     max_interesting_heights: usize,
     nodes: Vec<TomlNode>,
     pool_identification: Option<PoolIdentification>,
+    countdown: Option<Countdown>,
 }
 
 #[derive(Clone)]
@@ -93,6 +102,7 @@ pub struct Network {
     pub max_interesting_heights: usize,
     pub nodes: Vec<BoxedSyncSendNode>,
     pub pool_identification: PoolIdentification,
+    pub countdown: Option<Countdown>,
 }
 
 impl fmt::Display for TomlNetwork {
@@ -300,6 +310,7 @@ fn parse_toml_network(
         max_interesting_heights: toml_network.max_interesting_heights,
         nodes,
         pool_identification: toml_network.pool_identification.clone().unwrap_or_default(),
+        countdown: toml_network.countdown.clone(),
     })
 }
 
@@ -532,6 +543,79 @@ mod tests {
         )
         .expect("config should parse");
         assert_eq!(config.networks[0].slug, "tn4");
+    }
+
+    #[test]
+    fn countdown_is_parsed_when_present() {
+        let config = parse_config(
+            r#"
+            database_path = ""
+            www_path = "./www"
+            query_interval = 15
+            address = "127.0.0.1:2323"
+            rss_base_url = ""
+            footer_html = ""
+
+            [[networks]]
+            id = 1
+            name = "Testnet 4"
+            description = ""
+            min_fork_height = 0
+            max_interesting_heights = 0
+
+                [networks.countdown]
+                height = 105
+                label = "Halving"
+
+                [[networks.nodes]]
+                id = 0
+                name = "Node A"
+                description = ""
+                rpc_host = "127.0.0.1"
+                rpc_port = 0
+                rpc_user = ""
+                rpc_password = ""
+        "#,
+        )
+        .expect("config should parse");
+        let countdown = config.networks[0]
+            .countdown
+            .as_ref()
+            .expect("countdown should be set");
+        assert_eq!(countdown.height, 105);
+        assert_eq!(countdown.label, "Halving");
+    }
+
+    #[test]
+    fn countdown_is_none_when_absent() {
+        let config = parse_config(
+            r#"
+            database_path = ""
+            www_path = "./www"
+            query_interval = 15
+            address = "127.0.0.1:2323"
+            rss_base_url = ""
+            footer_html = ""
+
+            [[networks]]
+            id = 1
+            name = "Testnet 4"
+            description = ""
+            min_fork_height = 0
+            max_interesting_heights = 0
+
+                [[networks.nodes]]
+                id = 0
+                name = "Node A"
+                description = ""
+                rpc_host = "127.0.0.1"
+                rpc_port = 0
+                rpc_user = ""
+                rpc_password = ""
+        "#,
+        )
+        .expect("config should parse");
+        assert!(config.networks[0].countdown.is_none());
     }
 
     #[test]

--- a/src/headertree.rs
+++ b/src/headertree.rs
@@ -76,6 +76,7 @@ pub async fn strip_tree(
     tree: &Tree,
     max_interesting_heights: usize,
     tip_heights: BTreeSet<u64>,
+    countdown_height: Option<u64>,
 ) -> Vec<HeaderInfoJson> {
     let interesting_heights =
         sorted_interesting_heights(tree, max_interesting_heights, tip_heights).await;
@@ -85,6 +86,13 @@ pub async fn strip_tree(
     // Drop headers from our header tree that aren't 'interesting'.
     let mut striped_tree = tree_locked.0.filter_map(
         |_, header| {
+            // Always keep the blocks around a configured countdown height
+            // (height-2 ..= height+2), regardless of max_interesting_heights.
+            if let Some(ch) = countdown_height {
+                if header.height + 2 >= ch && header.height <= ch.saturating_add(2) {
+                    return Some(header);
+                }
+            }
             // Keep some surrounding headers for the headers we find interesting.
             for x in -2i64..=1 {
                 if interesting_heights.contains(&((header.height as i64 - x) as u64)) {
@@ -285,13 +293,13 @@ pub async fn recent_forks(tree: &Tree, how_many: usize) -> Vec<Fork> {
 
 #[cfg(test)]
 mod tests {
-    use super::stale_blocks;
+    use super::{stale_blocks, strip_tree};
     use crate::types::{HeaderInfo, Tree, TreeInfo};
     use corepc_client::bitcoin::blockdata::block::{Header, Version};
     use corepc_client::bitcoin::hashes::Hash;
     use corepc_client::bitcoin::{BlockHash, CompactTarget, TxMerkleNode};
     use petgraph::graph::DiGraph;
-    use std::collections::HashMap;
+    use std::collections::{BTreeSet, HashMap};
     use std::sync::Arc;
     use tokio::sync::Mutex;
 
@@ -438,5 +446,81 @@ mod tests {
         assert_eq!(stale[0].height, 6);
         assert_eq!(stale[1].height, 5);
         assert_eq!(stale[2].height, 4);
+    }
+
+    // Builds a linear chain of headers at heights 0..=max_height.
+    fn linear_chain(max_height: u64) -> Vec<HeaderInfo> {
+        let mut headers = vec![hi(0, header(BlockHash::all_zeros(), EASY_BITS, 0))];
+        for height in 1..=max_height {
+            let prev = headers.last().unwrap().header.block_hash();
+            headers.push(hi(height, header(prev, EASY_BITS, height as u32)));
+        }
+        headers
+    }
+
+    #[tokio::test]
+    async fn countdown_keeps_surrounding_five_blocks_bypassing_the_cap() {
+        // A long linear chain with a tiny max_interesting_heights, so without a
+        // countdown only heights near the tip would be kept.
+        let headers = linear_chain(20);
+        let tree = tree_from(&headers);
+
+        let result = strip_tree(&tree, 1, BTreeSet::new(), Some(10)).await;
+        let heights: Vec<u64> = result.iter().map(|h| h.height).collect();
+
+        for expected in 8..=12u64 {
+            assert!(
+                heights.contains(&expected),
+                "height {} should be kept around the countdown",
+                expected
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn countdown_near_zero_does_not_underflow() {
+        let headers = linear_chain(10);
+        let tree = tree_from(&headers);
+
+        let result = strip_tree(&tree, 1, BTreeSet::new(), Some(1)).await;
+        let heights: Vec<u64> = result.iter().map(|h| h.height).collect();
+
+        for expected in 0..=3u64 {
+            assert!(
+                heights.contains(&expected),
+                "height {} should be kept around a countdown near zero",
+                expected
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn countdown_above_tip_only_includes_mined_blocks() {
+        // Chain only reaches height 5; countdown target (10) and its window
+        // aren't mined yet, so they can't appear even though requested.
+        let headers = linear_chain(5);
+        let tree = tree_from(&headers);
+
+        let result = strip_tree(&tree, 1, BTreeSet::new(), Some(10)).await;
+        let heights: Vec<u64> = result.iter().map(|h| h.height).collect();
+
+        for not_yet_mined in 8..=12u64 {
+            assert!(!heights.contains(&not_yet_mined));
+        }
+    }
+
+    #[tokio::test]
+    async fn no_countdown_behaves_like_before() {
+        // No forks, so only the max height (20) is interesting; capped at 3
+        // means only heights 18..=20 (the -2..=1 window around 20 that
+        // actually exists in the chain) are kept, with no countdown involved.
+        let headers = linear_chain(20);
+        let tree = tree_from(&headers);
+
+        let result = strip_tree(&tree, 3, BTreeSet::new(), None).await;
+        let mut heights: Vec<u64> = result.iter().map(|h| h.height).collect();
+        heights.sort();
+
+        assert_eq!(heights, vec![18, 19, 20]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,13 @@ async fn startup() -> Result<(config::Config, Db, Caches), MainError> {
 
 async fn populate_cache(network: &config::Network, tree: &Tree, caches: &Caches) {
     let forks = headertree::recent_forks(&tree, MAX_FORKS_IN_CACHE).await;
-    let hij = headertree::strip_tree(&tree, network.max_interesting_heights, BTreeSet::new()).await;
+    let hij = headertree::strip_tree(
+        &tree,
+        network.max_interesting_heights,
+        BTreeSet::new(),
+        network.countdown.as_ref().map(|c| c.height),
+    )
+    .await;
     let stale_blocks = headertree::stale_blocks(&tree, MAX_STALE_BLOCKS).await;
     {
         let mut locked_caches = caches.lock().await;
@@ -325,6 +331,7 @@ async fn main() -> Result<(), MainError> {
                                 &tree_clone,
                                 network.max_interesting_heights,
                                 tip_heights,
+                                network.countdown.as_ref().map(|c| c.height),
                             )
                             .await;
                             let forks =
@@ -380,6 +387,10 @@ async fn main() -> Result<(), MainError> {
                         || interesting_heights.contains(&(h + 1))
                         || interesting_heights.contains(&(h + 2))
                         || interesting_heights.contains(&(max(h, 1) - 1))
+                        || network_clone
+                            .countdown
+                            .as_ref()
+                            .is_some_and(|c| h + 2 >= c.height && h <= c.height.saturating_add(2))
                 })
                 .map(|node| node.weight.clone())
             {

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use crate::config::Network;
+use crate::config::{Countdown, Network};
 use crate::node::NodeInfo;
 
 use corepc_client::bitcoin::blockdata::block::Header;
@@ -132,6 +132,8 @@ pub struct InfoJsonResponse {
 pub struct DataJsonResponse {
     pub header_infos: Vec<HeaderInfoJson>,
     pub nodes: Vec<NodeDataJson>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub countdown: Option<Countdown>,
 }
 
 /// A stale block: a block that is not part of the active chain. This includes

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -140,6 +140,29 @@ text.text-blocks-not-shown {
  font-size: 12px;
 }
 
+line.countdown-line {
+  stroke: var(--text-color);
+  stroke-width: 1px;
+  stroke-dasharray: 8 6;
+}
+
+text.countdown-label {
+  fill: var(--text-color);
+  font-size: 14px;
+}
+
+.countdown-display {
+  position: absolute;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 2.5rem;
+  font-weight: 600;
+  color: var(--text-color);
+  pointer-events: none;
+  z-index: 10;
+}
+
 rect.block-background {
  fill: var(--surface-bg);
 }

--- a/www/fullscreen.html
+++ b/www/fullscreen.html
@@ -15,8 +15,9 @@
 <body>
   <div class="container-fluid" style="display: flex; flex-direction: column; min-height: 100vh;">
     <main style="flex: 1;">
-      <div style="display: flex; flex-direction: column;">
+      <div style="display: flex; flex-direction: column; position: relative;">
         <svg style="flex:1; flex-basis: 98vh; height: 98vh;" id="drawing-area"></svg>
+        <div id="countdown-display" class="countdown-display" style="display: none"></div>
         <div>
           <label>Orientation <select name="orientation" id="orientation"></select></label>
         </div>

--- a/www/index.html
+++ b/www/index.html
@@ -48,6 +48,7 @@
       <div class="viz-wrap">
         <svg class="viz border" id="drawing-area"></svg>
         <button type="button" class="viz-recenter" id="recenter" title="Recenter on the chain tip" onclick="recenter()">re-center</button>
+        <div id="countdown-display" class="countdown-display" style="display: none"></div>
       </div>
       <details class="text-muted">
         <summary>Tip status legend</summary>

--- a/www/js/blocktree.js
+++ b/www/js/blocktree.js
@@ -24,6 +24,11 @@ const orientations = {
     // where the tip block should land in the viewport on the initial draw: the chain
     // grows downward, so put the tip near the top to show less empty space.
     tip_anchor: (w, h) => [w/2, h*0.25],
+    // the along-chain axis is y (growing negative), so the countdown marker is a
+    // horizontal line at a fixed y spanning the cross axis (x).
+    countdown_along: (idx) => -idx * NODE_SIZE,
+    countdown_line: (along, cross_min, cross_max) => ({x1: cross_min, y1: along, x2: cross_max, y2: along}),
+    countdown_label_pos: (along, cross_min) => ({x: cross_min, y: along}),
   },
   "left-to-right": {
     x: (d, htoi) => htoi[d.data.data.height] * NODE_SIZE,
@@ -41,8 +46,17 @@ const orientations = {
     // where the tip block should land in the viewport on the initial draw: the chain
     // grows rightward, so put the tip near the right to show less empty space.
     tip_anchor: (w, h) => [w*0.75, h/2],
+    // the along-chain axis is x, so the countdown marker is a vertical line at a
+    // fixed x spanning the cross axis (y).
+    countdown_along: (idx) => idx * NODE_SIZE,
+    countdown_line: (along, cross_min, cross_max) => ({x1: along, y1: cross_min, x2: along, y2: cross_max}),
+    countdown_label_pos: (along, cross_min) => ({x: along, y: cross_min}),
   },
 };
+
+// A countdown marker is only drawn once the chain tip is within this many
+// blocks of the configured countdown height.
+const COUNTDOWN_MARKER_THRESHOLD = 10
 
 const status_to_color = {
   "active": "lime",
@@ -103,6 +117,12 @@ let connectorLayer = g
 let descLayer = g
     .append("g")
     .attr("id", "descriptions")
+
+// layer holding the countdown marker line + label, redrawn from scratch on every
+// draw() call (cheap: at most one line and one text).
+let countdownLayer = g
+    .append("g")
+    .attr("id", "countdown")
 
 function preprocess_data(data) {
   let header_infos = data.header_infos;
@@ -415,6 +435,8 @@ function draw() {
     offset_y = o.y(max_height_tip, htoi);
   }
 
+  draw_countdown(htoi, max_height, root_node)
+
   // stack, bottom to top: 3D depth faces, then the links over them, then the block
   // front faces (so links tuck behind the front face and look centered), then the
   // tip status markers
@@ -423,6 +445,7 @@ function draw() {
   g.selectAll(".text-blocks-not-shown").raise()
   blocks.raise()
   node_groups.raise()
+  countdownLayer.raise()
 
   // keep open descriptions (and their connectors) anchored to their block as the
   // layout shifts, and raise the overlay so the info boxes stay on top of everything
@@ -534,6 +557,11 @@ function isInteresting(node) {
     // the node has a status != "in-chain"
     return true
   }
+  if (state_data.countdown) {
+    if (node.data.height == state_data.countdown.height) {
+      return true
+    }
+  }
   return false
 }
 
@@ -550,6 +578,82 @@ function hidden_text_x(d, htoi) {
 }
 function hidden_text_y(d, htoi) {
   return o.y(d.target, htoi) - (o.y(d.target, htoi) - o.y(d.source, htoi)) / 2 + o.hidden_blocks_text.offset_y
+}
+
+// Draws (or clears) the countdown marker line + label in the tree, and the large
+// "N blocks until <label>" overlay. `root_node`'s cross-axis coordinate (d.x, the
+// tree layout's own x) is shared by both orientations, only its final x/y slot
+// differs - see the `orientations` config.
+function draw_countdown(htoi, max_height, root_node) {
+  const cd = state_data.countdown
+  const display = document.getElementById("countdown-display")
+
+  if (!cd) {
+    countdownLayer.selectAll("*").remove()
+    if (display) display.style.display = "none"
+    return
+  }
+
+  const blocks_left = cd.height - max_height
+
+  if (display) {
+    if (blocks_left > 0) {
+      const unit = blocks_left == 1 ? "block" : "blocks"
+      display.textContent = `${blocks_left} ${unit} until ${cd.label}`
+      display.style.display = ""
+    } else if (blocks_left == 0) {
+      display.textContent = `${cd.label} now`
+      display.style.display = ""
+    } else if (blocks_left < 0 && blocks_left > -10) {
+      const unit = blocks_left == -1 ? "block" : "blocks"
+      display.textContent = `${blocks_left * -1} ${unit} ago: ${cd.label}`
+      display.style.display = ""
+    } else {
+      display.style.display = "none"
+    }
+  }
+
+  // Only draw the marker once we're close to the target; once shown (including
+  // after the target height has been reached) it is never hidden again, since
+  // blocks_left stays <= 0 (and thus < the threshold) from then on.
+  if (blocks_left >= COUNTDOWN_MARKER_THRESHOLD) {
+    countdownLayer.selectAll("*").remove()
+    return
+  }
+
+  const idx = cd.height in htoi ? htoi[cd.height] : htoi[max_height] + blocks_left
+  // Sit the marker between height-1 and height rather than centered on the
+  // target block itself (assumes the two are adjacent slots, which holds here
+  // since the backend always keeps height-2..height+2 once mined).
+  const along = o.countdown_along(idx - 0.4)
+
+  const cross_values = root_node.descendants().map(d => d.x)
+  const cross_min = Math.min(...cross_values) - NODE_SIZE
+  const cross_max = Math.max(...cross_values) + NODE_SIZE
+  const label_cross = cross_min - 16
+
+  const line_coords = o.countdown_line(along, cross_min, cross_max)
+  const label_pos = o.countdown_label_pos(along, label_cross)
+
+  countdownLayer.selectAll("line.countdown-line")
+    .data([line_coords])
+    .join("line")
+    .attr("class", "countdown-line")
+    .attr("x1", d => d.x1)
+    .attr("y1", d => d.y1)
+    .attr("x2", d => d.x2)
+    .attr("y2", d => d.y2)
+
+  countdownLayer.selectAll("text.countdown-label")
+    .data([label_pos])
+    .join("text")
+    .attr("class", "countdown-label")
+    .style("text-anchor", "middle")
+    .attr("x", d => d.x)
+    .attr("y", d => d.y)
+    .attr("transform", d => `rotate(${o.block_text_rotate}, ${d.x}, ${d.y})`)
+    .attr("dy", ".3em")
+    .text(cd.label)
 }
 
 function onBlockClick(c, d) {


### PR DESCRIPTION
allows adding one countdown per network to allow showing e.g. the halving or soft-fork activations