### PR TITLE
add: support for a remote fork-observer backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,41 @@ implementation = "electrum"
 this backend never reports forks, only the active tip. Only add it to a
 network that already has at least one Bitcoin Core (or btcd) node.
 
+## Connecting to another fork-observer instance
+
+A network can also import the nodes and headers of another fork-observer instance. This
+is fetched via the remote instance's HTTP API every `query_interval` seconds and merged
+into the local network's header tree, so the remote's nodes show up alongside the
+locally configured ones, marked with a `via <name>` label. `network_id` is the id of
+the network on the *remote* instance;
+`node_id_offset` is added to the remote's node ids to avoid colliding with locally
+configured node ids. It must be unique per remote source and larger than any node id
+used in this network.
+
+```toml
+[[networks.forkobservers]]
+name = "b10c's observer"
+description = "Another fork-observer instance"
+url = "https://fork-observer.example.com"
+network_id = 1
+node_id_offset = 1000
+```
+
+A node that a remote instance itself imported from yet another instance is never
+re-imported - propagation stops after one hop. This makes it safe to point two
+fork-observer instances at each other: each side only ever shows the other's own nodes,
+rather than the two accumulating each other's imports indefinitely.
+
+> [!NOTE]
+> A remote instance serves the same stripped-down header tree it shows in its own
+> frontend, not every header it knows: headers at heights it considers uninteresting
+> (see `max_interesting_heights`) are not part of the response and can't be imported.
+>
+> Imported headers are checked to hash to the block hash the remote reports, but
+> nothing beyond that is verified - heights and miners are taken at face value and
+> are written to the local database permanently. Only import from an instance you
+> trust as much as you'd trust one of your own nodes.
+
 ## Countdown to a block height
 
 Each network can optionally show a countdown to a specific block height (e.g. a

--- a/config.toml.example
+++ b/config.toml.example
@@ -111,6 +111,20 @@ max_interesting_heights = 100
     rpc_host = "https://block-dn.org"
     implementation = "block-dn"
 
+    # Show another fork-observer instance's nodes and headers alongside the
+    # ones configured above. The remote's data is fetched via its HTTP API
+    # every query_interval seconds and merged into this network's header tree.
+    # `node_id_offset` is added to the remote's node ids to avoid colliding
+    # with the node ids configured above; it must be unique per remote source
+    # and larger than any locally used node id. See the README for what is
+    # (and isn't) imported and verified.
+    # [[networks.forkobservers]]
+    # name = "b10c's observer"
+    # description = "Another fork-observer instance"
+    # url = "https://fork-observer.example.com"
+    # network_id = 1
+    # node_id_offset = 1000
+
 [[networks]]
 id = 0xFFFFFFFE
 name = "FFFFFFFE testnetwork"

--- a/src/api.rs
+++ b/src/api.rs
@@ -416,6 +416,7 @@ mod tests {
             min_fork_height: 0,
             max_interesting_heights: 100,
             nodes,
+            remote_forkobservers: vec![],
             pool_identification: PoolIdentification::default(),
             countdown: None,
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,6 +90,7 @@ struct TomlNetwork {
     min_fork_height: u64,
     max_interesting_heights: usize,
     nodes: Vec<TomlNode>,
+    forkobservers: Option<Vec<TomlRemoteForkObserver>>,
     pool_identification: Option<PoolIdentification>,
     countdown: Option<Countdown>,
 }
@@ -103,8 +104,33 @@ pub struct Network {
     pub min_fork_height: u64,
     pub max_interesting_heights: usize,
     pub nodes: Vec<BoxedSyncSendNode>,
+    pub remote_forkobservers: Vec<RemoteForkObserver>,
     pub pool_identification: PoolIdentification,
     pub countdown: Option<Countdown>,
+}
+
+/// Another fork-observer instance used as a data source: its header and node
+/// information is fetched via its HTTP API and shown alongside the local nodes.
+#[derive(Debug, Deserialize, Clone)]
+struct TomlRemoteForkObserver {
+    name: String,
+    description: Option<String>,
+    url: String,
+    network_id: u32,
+    node_id_offset: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct RemoteForkObserver {
+    pub name: String,
+    pub description: String,
+    /// Base URL of the remote instance, normalized: carries a scheme and has
+    /// no trailing slash.
+    pub url: String,
+    /// The id of the network ON THE REMOTE instance to fetch data from.
+    pub network_id: u32,
+    /// Added to the remote node ids to avoid collisions with local node ids.
+    pub node_id_offset: u32,
 }
 
 impl fmt::Display for TomlNetwork {
@@ -315,6 +341,27 @@ fn parse_toml_network(
         slug = toml_network.id.to_string();
     }
 
+    let max_local_node_id = nodes.iter().map(|n| n.info().id).max();
+    let mut remote_forkobservers: Vec<RemoteForkObserver> = vec![];
+    let mut offsets: Vec<u32> = vec![];
+    for toml_remote in toml_network
+        .forkobservers
+        .clone()
+        .unwrap_or_default()
+        .iter()
+    {
+        let remote = parse_toml_remote_forkobserver(toml_remote, max_local_node_id)?;
+        if offsets.contains(&remote.node_id_offset) {
+            error!(
+                "Duplicate node_id_offset {}: The remote fork-observer '{}' could not be loaded.",
+                remote.node_id_offset, remote.name
+            );
+            return Err(ConfigError::DuplicateRemoteNodeIdOffset);
+        }
+        offsets.push(remote.node_id_offset);
+        remote_forkobservers.push(remote);
+    }
+
     Ok(Network {
         id: toml_network.id,
         name: toml_network.name.clone(),
@@ -323,8 +370,41 @@ fn parse_toml_network(
         min_fork_height: toml_network.min_fork_height,
         max_interesting_heights: toml_network.max_interesting_heights,
         nodes,
+        remote_forkobservers,
         pool_identification: toml_network.pool_identification.clone().unwrap_or_default(),
         countdown: toml_network.countdown.clone(),
+    })
+}
+
+fn parse_toml_remote_forkobserver(
+    toml_remote: &TomlRemoteForkObserver,
+    max_local_node_id: Option<u32>,
+) -> Result<RemoteForkObserver, ConfigError> {
+    if toml_remote.url.trim().is_empty() {
+        return Err(ConfigError::InvalidRemoteForkObserver(format!(
+            "the remote fork-observer '{}' has an empty url",
+            toml_remote.name
+        )));
+    }
+    // The offset is added to the remote node ids. Requiring it to be larger
+    // than every local node id makes a collision with a local node impossible,
+    // so the poller doesn't have to handle one.
+    if toml_remote.node_id_offset <= max_local_node_id.unwrap_or(0) {
+        return Err(ConfigError::InvalidRemoteForkObserver(format!(
+            "the remote fork-observer '{}' has a node_id_offset of {} - it must be larger than every node id in this network (the largest is {}) to avoid id collisions",
+            toml_remote.name,
+            toml_remote.node_id_offset,
+            max_local_node_id.unwrap_or(0),
+        )));
+    }
+    Ok(RemoteForkObserver {
+        name: toml_remote.name.clone(),
+        description: toml_remote.description.clone().unwrap_or_default(),
+        url: ensure_scheme(toml_remote.url.trim())
+            .trim_end_matches('/')
+            .to_string(),
+        network_id: toml_remote.network_id,
+        node_id_offset: toml_remote.node_id_offset,
     })
 }
 
@@ -774,6 +854,142 @@ mod tests {
             // test OK, as we expect this to error
         } else {
             panic!("Test did not error!");
+        }
+    }
+
+    #[test]
+    fn remote_forkobserver_parsing() {
+        let config = parse_config(
+            r#"
+            database_path = ""
+            www_path = "./www"
+            query_interval = 15
+            address = "127.0.0.1:2323"
+            rss_base_url = ""
+            footer_html = ""
+
+            [[networks]]
+            id = 1
+            name = "Mainnet"
+            description = ""
+            min_fork_height = 0
+            max_interesting_heights = 0
+
+                [[networks.nodes]]
+                id = 0
+                name = "Node A"
+                description = ""
+                rpc_host = "127.0.0.1"
+                rpc_port = 0
+                rpc_user = ""
+                rpc_password = ""
+
+                [[networks.forkobservers]]
+                name = "example observer"
+                url = "fork-observer.example.com/"
+                network_id = 7
+                node_id_offset = 1000
+        "#,
+        )
+        .expect("config with a remote fork-observer should parse");
+        let remotes = &config.networks[0].remote_forkobservers;
+        assert_eq!(remotes.len(), 1);
+        assert_eq!(remotes[0].name, "example observer");
+        // Scheme is added and the trailing slash is trimmed.
+        assert_eq!(remotes[0].url, "http://fork-observer.example.com");
+        assert_eq!(remotes[0].network_id, 7);
+        assert_eq!(remotes[0].node_id_offset, 1000);
+        assert_eq!(remotes[0].description, "");
+    }
+
+    #[test]
+    fn error_on_duplicate_remote_forkobserver_offset() {
+        match parse_config(
+            r#"
+            database_path = ""
+            www_path = "./www"
+            query_interval = 15
+            address = "127.0.0.1:2323"
+            rss_base_url = ""
+            footer_html = ""
+
+            [[networks]]
+            id = 1
+            name = "Mainnet"
+            description = ""
+            min_fork_height = 0
+            max_interesting_heights = 0
+
+                [[networks.nodes]]
+                id = 0
+                name = "Node A"
+                description = ""
+                rpc_host = "127.0.0.1"
+                rpc_port = 0
+                rpc_user = ""
+                rpc_password = ""
+
+                [[networks.forkobservers]]
+                name = "observer 1"
+                url = "https://one.example.com"
+                network_id = 1
+                node_id_offset = 1000
+
+                [[networks.forkobservers]]
+                name = "observer 2"
+                url = "https://two.example.com"
+                network_id = 1
+                node_id_offset = 1000
+        "#,
+        ) {
+            Err(ConfigError::DuplicateRemoteNodeIdOffset) => {
+                // test OK, as we expect this to error
+            }
+            _ => panic!("expected DuplicateRemoteNodeIdOffset error"),
+        }
+    }
+
+    #[test]
+    fn error_on_invalid_remote_forkobserver() {
+        for (url, node_id_offset) in [("https://example.com", 0), ("  ", 1000)] {
+            match parse_config(&format!(
+                r#"
+                database_path = ""
+                www_path = "./www"
+                query_interval = 15
+                address = "127.0.0.1:2323"
+                rss_base_url = ""
+                footer_html = ""
+
+                [[networks]]
+                id = 1
+                name = "Mainnet"
+                description = ""
+                min_fork_height = 0
+                max_interesting_heights = 0
+
+                    [[networks.nodes]]
+                    id = 0
+                    name = "Node A"
+                    description = ""
+                    rpc_host = "127.0.0.1"
+                    rpc_port = 0
+                    rpc_user = ""
+                    rpc_password = ""
+
+                    [[networks.forkobservers]]
+                    name = "observer"
+                    url = "{}"
+                    network_id = 1
+                    node_id_offset = {}
+            "#,
+                url, node_id_offset
+            )) {
+                Err(ConfigError::InvalidRemoteForkObserver(_)) => {
+                    // test OK, as we expect this to error
+                }
+                _ => panic!("expected InvalidRemoteForkObserver error"),
+            }
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -128,6 +128,8 @@ pub enum ConfigError {
     DuplicateNodeId,
     DuplicateNetworkId,
     DuplicateNetworkSlug,
+    DuplicateRemoteNodeIdOffset,
+    InvalidRemoteForkObserver(String),
     TomlError(toml::de::Error),
     ReadError(io::Error),
     AddrError(AddrParseError),
@@ -144,6 +146,8 @@ impl fmt::Display for ConfigError {
             ConfigError::DuplicateNodeId => write!(f, "a node id has been used multiple times in the same network"),
             ConfigError::DuplicateNetworkId => write!(f, "a network id has been used multiple times"),
             ConfigError::DuplicateNetworkSlug => write!(f, "a network slug has been used multiple times (slugs must be unique; set an explicit `slug` for one of the networks)"),
+            ConfigError::DuplicateRemoteNodeIdOffset => write!(f, "a node_id_offset has been used multiple times by remote fork-observers in the same network"),
+            ConfigError::InvalidRemoteForkObserver(e) => write!(f, "invalid remote fork-observer configuration: {}", e),
             ConfigError::TomlError(e) => write!(f, "the TOML in the configuration file could not be parsed: {}", e),
             ConfigError::ReadError(e) => write!(f, "the configuration file could not be read: {}", e),
             ConfigError::AddrError(e) => write!(f, "the address could not be parsed: {}", e),
@@ -165,6 +169,8 @@ impl error::Error for ConfigError {
             ConfigError::DuplicateNodeId => None,
             ConfigError::DuplicateNetworkId => None,
             ConfigError::DuplicateNetworkSlug => None,
+            ConfigError::DuplicateRemoteNodeIdOffset => None,
+            ConfigError::InvalidRemoteForkObserver(_) => None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod error;
 mod headertree;
 mod jsonrpc;
 mod node;
+mod remote_forkobserver;
 mod rss;
 mod types;
 
@@ -139,10 +140,11 @@ async fn main() -> Result<(), MainError> {
         let (pool_id_tx, mut pool_id_rx) = unbounded_channel::<BlockHash>();
 
         info!(
-            "network '{}' (id={}) has {} nodes",
+            "network '{}' (id={}) has {} nodes and {} remote fork-observer source(s)",
             network.name,
             network.id,
-            network.nodes.len()
+            network.nodes.len(),
+            network.remote_forkobservers.len()
         );
 
         let tree: Tree = Arc::new(Mutex::new(
@@ -322,31 +324,11 @@ async fn main() -> Result<(), MainError> {
                         .await;
 
                         if tree_changed {
-                            let mut tip_heights: BTreeSet<u64> =
-                                tip_heights(network.id, &caches_clone).await;
-                            for tip in tips.iter() {
-                                tip_heights.insert(tip.height);
-                            }
-                            let header_infos_json = headertree::strip_tree(
+                            update_header_tree_cache(
+                                &network,
                                 &tree_clone,
-                                network.max_interesting_heights,
-                                tip_heights,
-                                network.countdown.as_ref().map(|c| c.height),
-                            )
-                            .await;
-                            let forks =
-                                headertree::recent_forks(&tree_clone, MAX_FORKS_IN_CACHE).await;
-                            let stale_blocks =
-                                headertree::stale_blocks(&tree_clone, MAX_STALE_BLOCKS).await;
-
-                            update_cache(
                                 &caches_clone,
-                                network.id,
-                                CacheUpdate::HeaderTree {
-                                    header_infos_json,
-                                    forks,
-                                    stale_blocks,
-                                },
+                                tips.iter().map(|t| t.height),
                                 &cache_changed_tx_cloned,
                             )
                             .await;
@@ -354,6 +336,18 @@ async fn main() -> Result<(), MainError> {
                     }
                 }
             });
+        }
+
+        for remote in network.remote_forkobservers.iter().cloned() {
+            task::spawn(remote_forkobserver::run_poller(
+                remote,
+                network.clone(),
+                tree.clone(),
+                db.clone(),
+                caches.clone(),
+                cache_changed_tx.clone(),
+                config.query_interval,
+            ));
         }
 
         // A one-shot thread trying to identify all unidentified miners. This
@@ -546,6 +540,42 @@ async fn tip_heights(network_id: u32, caches: &Caches) -> BTreeSet<u64> {
     tip_heights
 }
 
+/// Recomputes the stripped header tree, the recent forks and the stale blocks
+/// of a network and pushes them into the cache. Call this after new headers
+/// were inserted into the tree. `extra_tip_heights` are heights to keep in
+/// addition to the tips already in the cache (a caller that just learned about
+/// new tips might not have them in the cache yet).
+async fn update_header_tree_cache(
+    network: &config::Network,
+    tree: &Tree,
+    caches: &Caches,
+    extra_tip_heights: impl IntoIterator<Item = u64>,
+    cache_changed_tx: &broadcast::Sender<u32>,
+) {
+    let mut tip_heights: BTreeSet<u64> = tip_heights(network.id, caches).await;
+    tip_heights.extend(extra_tip_heights);
+    let header_infos_json = headertree::strip_tree(
+        tree,
+        network.max_interesting_heights,
+        tip_heights,
+        network.countdown.as_ref().map(|c| c.height),
+    )
+    .await;
+    let forks = headertree::recent_forks(tree, MAX_FORKS_IN_CACHE).await;
+    let stale_blocks = headertree::stale_blocks(tree, MAX_STALE_BLOCKS).await;
+    update_cache(
+        caches,
+        network.id,
+        CacheUpdate::HeaderTree {
+            header_infos_json,
+            forks,
+            stale_blocks,
+        },
+        cache_changed_tx,
+    )
+    .await;
+}
+
 #[derive(Debug)]
 enum CacheUpdate {
     HeaderMiner {
@@ -567,6 +597,14 @@ enum CacheUpdate {
     NodeVersion {
         node_id: u32,
         version: String,
+    },
+    /// Replaces the node entries injected by a remote fork-observer source:
+    /// `removed_node_ids` are dropped from the cache and `nodes` are inserted
+    /// (or updated) by id. The poller owns which ids are "its", so it computes
+    /// the delta each poll.
+    RemoteNodes {
+        removed_node_ids: Vec<u32>,
+        nodes: Vec<NodeDataJson>,
     },
 }
 
@@ -603,6 +641,17 @@ impl fmt::Display for CacheUpdate {
             }
             CacheUpdate::NodeReachability { node_id, reachable } => {
                 write!(f, "Setting node {} to reachable={}", node_id, reachable)
+            }
+            CacheUpdate::RemoteNodes {
+                removed_node_ids,
+                nodes,
+            } => {
+                write!(
+                    f,
+                    "Updating {} remote node(s), removing {} remote node(s)",
+                    nodes.len(),
+                    removed_node_ids.len()
+                )
             }
         }
     }
@@ -720,6 +769,19 @@ async fn update_cache(
                     .node_data
                     .entry(node_id)
                     .and_modify(|e| e.version(version));
+            });
+        }
+        CacheUpdate::RemoteNodes {
+            removed_node_ids,
+            nodes,
+        } => {
+            locked_cache.entry(network_id).and_modify(|network| {
+                for id in removed_node_ids.iter() {
+                    network.node_data.remove(id);
+                }
+                for node in nodes.into_iter() {
+                    network.node_data.insert(node.id, node);
+                }
             });
         }
     }
@@ -892,6 +954,83 @@ mod tests {
             get_test_node_reachable(&caches, network_id, node.id).await,
             true
         );
+    }
+
+    #[tokio::test]
+    async fn remote_nodes_update_inserts_replaces_and_removes() {
+        let network_id: u32 = 0;
+        let (dummy_sender, _) = broadcast::channel(2);
+        let caches: Caches = Arc::new(Mutex::new(BTreeMap::new()));
+        {
+            let mut locked_caches = caches.lock().await;
+            locked_caches.insert(
+                network_id,
+                Cache {
+                    header_infos_json: vec![],
+                    node_data: BTreeMap::new(),
+                    forks: vec![],
+                    stale_blocks: vec![],
+                    block_cache: HashMap::new(),
+                    recent_miners: vec![],
+                },
+            );
+        }
+
+        let node_info = |id: u32, name: &str| NodeInfo {
+            id,
+            name: name.to_string(),
+            description: "".to_string(),
+            implementation: "".to_string(),
+        };
+
+        // Insert two remote nodes.
+        update_cache(
+            &caches,
+            network_id,
+            CacheUpdate::RemoteNodes {
+                removed_node_ids: vec![],
+                nodes: vec![
+                    NodeDataJson::new(node_info(1000, "A"), &vec![], "".to_string(), 0, true),
+                    NodeDataJson::new(node_info(1001, "B"), &vec![], "".to_string(), 0, true),
+                ],
+            },
+            &dummy_sender,
+        )
+        .await;
+        {
+            let locked = caches.lock().await;
+            let node_data = &locked.get(&network_id).unwrap().node_data;
+            assert_eq!(node_data.len(), 2);
+            assert!(node_data.contains_key(&1000));
+            assert!(node_data.contains_key(&1001));
+        }
+
+        // Replace node 1000's data and remove node 1001.
+        update_cache(
+            &caches,
+            network_id,
+            CacheUpdate::RemoteNodes {
+                removed_node_ids: vec![1001],
+                nodes: vec![NodeDataJson::new(
+                    node_info(1000, "A renamed"),
+                    &vec![],
+                    "".to_string(),
+                    0,
+                    false,
+                )],
+            },
+            &dummy_sender,
+        )
+        .await;
+        {
+            let locked = caches.lock().await;
+            let node_data = &locked.get(&network_id).unwrap().node_data;
+            assert_eq!(node_data.len(), 1);
+            let node = node_data.get(&1000).unwrap();
+            assert_eq!(node.name, "A renamed");
+            assert_eq!(node.reachable, false);
+            assert!(!node_data.contains_key(&1001));
+        }
     }
 
     #[tokio::test]

--- a/src/remote_forkobserver.rs
+++ b/src/remote_forkobserver.rs
@@ -1,0 +1,633 @@
+//! Support for using another fork-observer instance as a data source.
+//!
+//! A remote fork-observer (configured per network with a base URL and the id
+//! of a network on the remote instance) is polled via its HTTP API. The
+//! headers it knows about are merged into the local header tree and its nodes
+//! are shown alongside the locally configured nodes.
+
+use std::collections::BTreeSet;
+use std::str::FromStr;
+
+use corepc_client::bitcoin::blockdata::block::{Header, Version};
+use corepc_client::bitcoin::{BlockHash, CompactTarget, TxMerkleNode};
+use log::{debug, error, info, warn};
+use tokio::sync::broadcast;
+use tokio::task;
+use tokio::time::{interval, Duration, MissedTickBehavior};
+
+use crate::config::{Network, RemoteForkObserver};
+use crate::db;
+use crate::error::FetchError;
+use crate::types::{
+    Caches, DataJsonResponse, Db, HeaderInfo, HeaderInfoJson, NetworksJsonResponse, NodeDataJson,
+    Tree,
+};
+
+/// The remote's data.json can be considerably larger than a node RPC reply,
+/// so allow more time than the 8 seconds used for node requests.
+const REMOTE_TIMEOUT_SECS: u64 = 30;
+
+/// GETs `url` and deserializes the JSON response body. `minreq` is blocking,
+/// so this runs on the blocking pool.
+async fn get_json<T: serde::de::DeserializeOwned + Send + 'static>(
+    url: String,
+) -> Result<T, FetchError> {
+    task::spawn_blocking(move || {
+        let response = minreq::get(&url).with_timeout(REMOTE_TIMEOUT_SECS).send()?;
+        if response.status_code != 200 {
+            return Err(FetchError::DataError(format!(
+                "HTTP {} response to GET {}",
+                response.status_code, url
+            )));
+        }
+        Ok(response.json::<T>()?)
+    })
+    .await?
+}
+
+/// Rebuilds the exact block header from the remote's JSON representation and
+/// verifies that it hashes to the block hash the remote reported.
+fn header_info_from_json(hij: &HeaderInfoJson) -> Result<HeaderInfo, FetchError> {
+    let prev_blockhash = BlockHash::from_str(&hij.prev_blockhash).map_err(|e| {
+        FetchError::DataError(format!(
+            "invalid prev_blockhash '{}': {}",
+            hij.prev_blockhash, e
+        ))
+    })?;
+    let merkle_root = TxMerkleNode::from_str(&hij.merkle_root).map_err(|e| {
+        FetchError::DataError(format!("invalid merkle_root '{}': {}", hij.merkle_root, e))
+    })?;
+    let header = Header {
+        // exact round-trip of HeaderInfoJson::new's `to_consensus() as u32`
+        version: Version::from_consensus(hij.version as i32),
+        prev_blockhash,
+        merkle_root,
+        time: hij.time,
+        bits: CompactTarget::from_consensus(hij.bits),
+        nonce: hij.nonce,
+    };
+    if header.block_hash().to_string() != hij.hash {
+        return Err(FetchError::DataError(format!(
+            "header hash mismatch: remote claims {} but the header hashes to {}",
+            hij.hash,
+            header.block_hash()
+        )));
+    }
+    Ok(HeaderInfo {
+        height: hij.height,
+        header,
+        miner: hij.miner.clone(),
+    })
+}
+
+/// Converts a whole batch of remote headers. Any hash mismatch fails the whole
+/// batch: a mismatch means the remote is buggy or malicious and none of its
+/// data should be trusted. Headers below the local min_fork_height are dropped.
+fn header_infos_from_json(
+    hijs: &[HeaderInfoJson],
+    min_fork_height: u64,
+) -> Result<Vec<HeaderInfo>, FetchError> {
+    hijs.iter()
+        .filter(|hij| hij.height >= min_fork_height)
+        .map(header_info_from_json)
+        .collect()
+}
+
+/// Prepares the remote's nodes to be shown alongside the local nodes: node ids
+/// are offset to avoid collisions with local node ids and the remote's name is
+/// recorded so the frontend can mark where the node came from. Nodes the remote
+/// itself imported from a third instance are dropped, see
+/// [`NodeDataJson::remote_source`]. The remote-reported
+/// tips, version, reachability, and timestamp are kept as-is (e.g. a node
+/// unreachable *on the remote* stays marked unreachable here).
+fn prepare_remote_nodes(
+    remote: &RemoteForkObserver,
+    nodes: Vec<NodeDataJson>,
+) -> Vec<NodeDataJson> {
+    let mut prepared: Vec<NodeDataJson> = Vec::with_capacity(nodes.len());
+    for mut node in nodes.into_iter() {
+        if node.remote_source.is_some() {
+            debug!(
+                "Not importing node '{}' from the remote fork-observer '{}': it was itself imported from another remote instance.",
+                node.name, remote.name
+            );
+            continue;
+        }
+        // The configuration requires node_id_offset to be larger than every
+        // local node id in this network, so an offset id can't collide with a
+        // local one. It can still overflow for absurdly large remote ids.
+        node.id = match node.id.checked_add(remote.node_id_offset) {
+            Some(id) => id,
+            None => {
+                error!(
+                    "The id of node '{}' from the remote fork-observer '{}' overflows when adding the node_id_offset {}. Skipping this node.",
+                    node.name, remote.name, remote.node_id_offset
+                );
+                continue;
+            }
+        };
+        node.remote_source = Some(remote.name.clone());
+        prepared.push(node);
+    }
+    prepared
+}
+
+#[derive(Default)]
+struct PollState {
+    /// The (already offset) node ids we injected into the cache last time.
+    last_node_ids: BTreeSet<u32>,
+    last_nodes: Vec<NodeDataJson>,
+    unreachable: bool,
+}
+
+async fn poll_once(
+    remote: &RemoteForkObserver,
+    network: &Network,
+    tree: &Tree,
+    db: &Db,
+    caches: &Caches,
+    cache_changed_tx: &broadcast::Sender<u32>,
+    state: &mut PollState,
+) -> Result<(), FetchError> {
+    let data: DataJsonResponse = get_json(format!(
+        "{}/api/{}/data.json",
+        remote.url, remote.network_id
+    ))
+    .await?;
+    let header_infos = header_infos_from_json(&data.header_infos, network.min_fork_height)?;
+
+    // Only insert and persist headers we don't know about yet. This avoids
+    // re-writing the (unchanged) remote headers to the database on every poll.
+    let new_headers: Vec<HeaderInfo> = {
+        let tree_locked = tree.lock().await;
+        header_infos
+            .into_iter()
+            .filter(|h| !tree_locked.1.contains_key(&h.header.block_hash()))
+            .collect()
+    };
+
+    let mut tree_changed = false;
+    if !new_headers.is_empty() {
+        tree_changed = crate::insert_new_headers_into_tree(tree, &new_headers).await;
+        match db::write_to_db(&new_headers, db.clone(), network.id).await {
+            Ok(_) => info!(
+                "Written {} headers to database for network '{}' from remote fork-observer '{}'",
+                new_headers.len(),
+                network.name,
+                remote.name
+            ),
+            Err(e) => error!(
+                "Could not write new headers for network '{}' from remote fork-observer '{}' to database: {}",
+                network.name, remote.name, e
+            ),
+        }
+    }
+
+    let nodes = prepare_remote_nodes(remote, data.nodes);
+    let node_ids: BTreeSet<u32> = nodes.iter().map(|n| n.id).collect();
+    let removed_node_ids: Vec<u32> = state.last_node_ids.difference(&node_ids).cloned().collect();
+
+    if state.unreachable || nodes != state.last_nodes || !removed_node_ids.is_empty() {
+        crate::update_cache(
+            caches,
+            network.id,
+            crate::CacheUpdate::RemoteNodes {
+                removed_node_ids,
+                nodes: nodes.clone(),
+            },
+            cache_changed_tx,
+        )
+        .await;
+    }
+    state.last_node_ids = node_ids;
+    state.last_nodes = nodes;
+    state.unreachable = false;
+
+    if tree_changed {
+        // No extra tip heights: the remote's tips are already in the cache, as
+        // the RemoteNodes update ran above.
+        crate::update_header_tree_cache(
+            network,
+            tree,
+            caches,
+            std::iter::empty(),
+            cache_changed_tx,
+        )
+        .await;
+    }
+    Ok(())
+}
+
+/// Best-effort check that the remote actually has the configured network. A
+/// mismatch or an unreachable remote only logs: the remote might be down or
+/// misconfigured right now and fixed later, so we keep polling either way.
+async fn check_remote_network(remote: &RemoteForkObserver) {
+    match get_json::<NetworksJsonResponse>(format!("{}/api/networks.json", remote.url)).await {
+        Ok(response) => {
+            if !response.networks.iter().any(|n| n.id == remote.network_id) {
+                error!(
+                    "The remote fork-observer '{}' ({}) has no network with id={}. Available networks: {}. Polling anyway - the remote might be reconfigured later.",
+                    remote.name,
+                    remote.url,
+                    remote.network_id,
+                    response
+                        .networks
+                        .iter()
+                        .map(|n| format!("'{}' (id={})", n.name, n.id))
+                        .collect::<Vec<String>>()
+                        .join(", ")
+                );
+            }
+        }
+        Err(e) => warn!(
+            "Could not fetch networks.json from the remote fork-observer '{}' ({}): {}. Polling anyway.",
+            remote.name, remote.url, e
+        ),
+    }
+}
+
+pub async fn run_poller(
+    remote: RemoteForkObserver,
+    network: Network,
+    tree: Tree,
+    db: Db,
+    caches: Caches,
+    cache_changed_tx: broadcast::Sender<u32>,
+    query_interval: Duration,
+) {
+    info!(
+        "Polling remote fork-observer '{}' ({}, '{}') for network '{}' (id={})",
+        remote.name, remote.url, remote.description, network.name, network.id
+    );
+    check_remote_network(&remote).await;
+
+    let mut state = PollState::default();
+    let mut ticker = interval(query_interval);
+    // A poll can take longer than query_interval (the remote's data.json is
+    // larger than a node RPC reply and the timeout is 30s). The default
+    // behavior would then fire the missed ticks back-to-back, hammering a
+    // remote that is already slow. Wait a full interval after each poll instead.
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    loop {
+        // The first tick fires immediately, so we poll right after startup.
+        ticker.tick().await;
+        if let Err(e) = poll_once(
+            &remote,
+            &network,
+            &tree,
+            &db,
+            &caches,
+            &cache_changed_tx,
+            &mut state,
+        )
+        .await
+        {
+            error!(
+                "Could not fetch data from the remote fork-observer '{}' ({}) for network '{}' (id={}): {}",
+                remote.name, remote.url, network.name, network.id, e
+            );
+            // Keep showing the last known data, but mark the injected nodes as
+            // unreachable (once - not on every failed poll).
+            if !state.unreachable && !state.last_nodes.is_empty() {
+                for node in state.last_nodes.iter_mut() {
+                    node.reachable = false;
+                }
+                crate::update_cache(
+                    &caches,
+                    network.id,
+                    crate::CacheUpdate::RemoteNodes {
+                        removed_node_ids: vec![],
+                        nodes: state.last_nodes.clone(),
+                    },
+                    &cache_changed_tx,
+                )
+                .await;
+            }
+            state.unreachable = true;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::PoolIdentification;
+    use crate::types::{Cache, HeaderInfoJson, NetworkJson, NodeDataJson};
+    use corepc_client::bitcoin::hashes::Hash;
+    use rusqlite::Connection;
+    use std::collections::{BTreeMap, HashMap};
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    // A trivially-easy target, same as used in headertree.rs's tests.
+    const EASY_BITS: u32 = 0x207f_ffff;
+
+    fn header(prev: BlockHash, nonce: u32) -> Header {
+        Header {
+            version: Version::from_consensus(0x2000_0000),
+            prev_blockhash: prev,
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 1_600_000_000,
+            bits: CompactTarget::from_consensus(EASY_BITS),
+            nonce,
+        }
+    }
+
+    #[test]
+    fn header_info_json_round_trips_and_verifies_hash() {
+        let hi = HeaderInfo {
+            height: 1,
+            header: header(BlockHash::all_zeros(), 42),
+            miner: "Some Pool".to_string(),
+        };
+        let hij = HeaderInfoJson::new(&hi, 0, usize::MAX);
+
+        let parsed = header_info_from_json(&hij).expect("a valid HeaderInfoJson should parse");
+        assert_eq!(parsed, hi);
+    }
+
+    #[test]
+    fn header_info_json_tampering_is_rejected() {
+        let hi = HeaderInfo {
+            height: 1,
+            header: header(BlockHash::all_zeros(), 42),
+            miner: "".to_string(),
+        };
+        let hij = HeaderInfoJson::new(&hi, 0, usize::MAX);
+
+        // Either changing the claimed hash or changing a header field breaks
+        // the hash check.
+        let mut claimed_hash = hij.clone();
+        claimed_hash.hash = BlockHash::all_zeros().to_string();
+        let mut header_field = hij.clone();
+        header_field.nonce = hij.nonce.wrapping_add(1);
+
+        for tampered in [claimed_hash, header_field] {
+            match header_info_from_json(&tampered) {
+                Err(FetchError::DataError(_)) => {}
+                other => panic!("expected a DataError, got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn header_infos_from_json_drops_headers_below_min_fork_height() {
+        let a = HeaderInfo {
+            height: 5,
+            header: header(BlockHash::all_zeros(), 1),
+            miner: "".to_string(),
+        };
+        let b = HeaderInfo {
+            height: 10,
+            header: header(a.header.block_hash(), 2),
+            miner: "".to_string(),
+        };
+        let hijs = vec![
+            HeaderInfoJson::new(&a, 0, usize::MAX),
+            HeaderInfoJson::new(&b, 1, 0),
+        ];
+
+        let kept = header_infos_from_json(&hijs, 10).expect("should parse");
+        assert_eq!(kept, vec![b]);
+    }
+
+    fn test_remote(node_id_offset: u32) -> RemoteForkObserver {
+        RemoteForkObserver {
+            name: "remote".to_string(),
+            description: "".to_string(),
+            url: "http://127.0.0.1:0".to_string(),
+            network_id: 1,
+            node_id_offset,
+        }
+    }
+
+    fn test_node(id: u32, name: &str) -> NodeDataJson {
+        NodeDataJson::new(
+            crate::node::NodeInfo {
+                id,
+                name: name.to_string(),
+                description: "".to_string(),
+                implementation: "test".to_string(),
+            },
+            &vec![],
+            "".to_string(),
+            0,
+            true,
+        )
+    }
+
+    #[test]
+    fn prepare_remote_nodes_offsets_and_labels() {
+        let remote = test_remote(1000);
+        let nodes = vec![test_node(0, "Node A")];
+        let prepared = prepare_remote_nodes(&remote, nodes);
+
+        assert_eq!(prepared.len(), 1);
+        assert_eq!(prepared[0].id, 1000);
+        // The name is left alone - where the node came from is a separate
+        // field, so the frontend can show it as its own label.
+        assert_eq!(prepared[0].name, "Node A");
+        // Marked so a further hop won't re-import it.
+        assert_eq!(prepared[0].remote_source.as_deref(), Some("remote"));
+        assert_eq!(prepared[0].display_name(), "Node A via remote");
+    }
+
+    #[test]
+    fn prepare_remote_nodes_does_not_reimport_already_remote_nodes() {
+        // A node the remote itself imported from some other instance must not
+        // be re-imported - this is what keeps a cycle between two mutually
+        // configured instances from accumulating nodes forever.
+        let remote = test_remote(1000);
+        let mut already_remote = test_node(0, "Node A");
+        already_remote.remote_source = Some("somewhere-else".to_string());
+        let nodes = vec![already_remote, test_node(1, "Node B")];
+
+        let prepared = prepare_remote_nodes(&remote, nodes);
+
+        assert_eq!(prepared.len(), 1);
+        assert_eq!(prepared[0].name, "Node B");
+    }
+
+    #[test]
+    fn prepare_remote_nodes_skips_offset_overflow() {
+        let remote = test_remote(u32::MAX);
+        let nodes = vec![test_node(1, "Node A")];
+        let prepared = prepare_remote_nodes(&remote, nodes);
+        assert!(prepared.is_empty());
+    }
+
+    fn test_network(id: u32) -> Network {
+        Network {
+            id,
+            description: String::new(),
+            name: format!("net{}", id),
+            slug: format!("net{}", id),
+            min_fork_height: 0,
+            max_interesting_heights: 100,
+            nodes: vec![],
+            remote_forkobservers: vec![],
+            countdown: None,
+            pool_identification: PoolIdentification::default(),
+        }
+    }
+
+    async fn empty_tree() -> Tree {
+        Arc::new(Mutex::new((
+            petgraph::graph::DiGraph::new(),
+            HashMap::new(),
+        )))
+    }
+
+    async fn memory_db() -> Db {
+        let conn = Connection::open_in_memory().expect("in-memory sqlite should open");
+        let db: Db = Arc::new(Mutex::new(conn));
+        db::setup_db(db.clone())
+            .await
+            .expect("db setup should succeed");
+        db
+    }
+
+    async fn empty_caches(network_id: u32) -> Caches {
+        let mut map = BTreeMap::new();
+        map.insert(
+            network_id,
+            Cache {
+                header_infos_json: vec![],
+                node_data: BTreeMap::new(),
+                forks: vec![],
+                stale_blocks: vec![],
+                block_cache: HashMap::new(),
+                recent_miners: vec![],
+            },
+        );
+        Arc::new(Mutex::new(map))
+    }
+
+    /// Serves a fixture `networks.json` + `data.json` on an ephemeral local
+    /// port, mimicking a real fork-observer instance, and returns its base URL.
+    async fn serve_fixture(
+        remote_network_id: u32,
+        header_infos: Vec<HeaderInfoJson>,
+        nodes: Vec<NodeDataJson>,
+    ) -> String {
+        use warp::Filter;
+
+        // `warp::Filter::map` requires the closure (and thus what it captures)
+        // to be `Clone`; the response structs aren't, so capture them via `Arc`.
+        let networks_json = Arc::new(NetworksJsonResponse {
+            networks: vec![NetworkJson {
+                id: remote_network_id,
+                name: "remote network".to_string(),
+                slug: "remote-network".to_string(),
+                description: "".to_string(),
+            }],
+        });
+        let data_json = Arc::new(DataJsonResponse {
+            header_infos,
+            nodes,
+            countdown: None,
+        });
+
+        let networks_route = warp::path!("api" / "networks.json")
+            .map(move || warp::reply::json(networks_json.as_ref()));
+        let data_route = warp::path!("api" / u32 / "data.json")
+            .map(move |_id: u32| warp::reply::json(data_json.as_ref()));
+        let routes = networks_route.or(data_route);
+
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("binding an ephemeral local port should succeed");
+        let addr = listener
+            .local_addr()
+            .expect("a bound listener should have a local address");
+        tokio::spawn(warp::serve(routes).incoming(listener).run());
+        format!("http://{}", addr)
+    }
+
+    #[tokio::test]
+    async fn poll_once_merges_remote_headers_and_nodes() {
+        let remote_network_id = 7;
+        let root = HeaderInfo {
+            height: 0,
+            header: header(BlockHash::all_zeros(), 0),
+            miner: "".to_string(),
+        };
+        let child = HeaderInfo {
+            height: 1,
+            header: header(root.header.block_hash(), 1),
+            miner: "Remote Pool".to_string(),
+        };
+        let header_infos = vec![
+            HeaderInfoJson::new(&root, 0, usize::MAX),
+            HeaderInfoJson::new(&child, 1, 0),
+        ];
+        let remote_nodes = vec![test_node(0, "Remote Node")];
+
+        let base_url = serve_fixture(remote_network_id, header_infos, remote_nodes).await;
+        let mut remote = test_remote(1000);
+        remote.url = base_url;
+        remote.network_id = remote_network_id;
+
+        let network = test_network(1);
+        let tree = empty_tree().await;
+        let db = memory_db().await;
+        let caches = empty_caches(network.id).await;
+        let (cache_changed_tx, mut cache_changed_rx) = broadcast::channel(16);
+        let mut state = PollState::default();
+
+        poll_once(
+            &remote,
+            &network,
+            &tree,
+            &db,
+            &caches,
+            &cache_changed_tx,
+            &mut state,
+        )
+        .await
+        .expect("poll_once should succeed against the fixture server");
+
+        // The remote's headers landed in the tree.
+        {
+            let tree_locked = tree.lock().await;
+            assert!(tree_locked.1.contains_key(&root.header.block_hash()));
+            assert!(tree_locked.1.contains_key(&child.header.block_hash()));
+        }
+
+        // ... and were persisted under the local network id.
+        let restored = db::load_treeinfos(db.clone(), network.id)
+            .await
+            .expect("tree should reload from the database");
+        assert_eq!(restored.1.len(), 2);
+
+        // The remote node shows up with an offset id and its source instance.
+        {
+            let locked_caches = caches.lock().await;
+            let node_data = &locked_caches.get(&network.id).unwrap().node_data;
+            assert_eq!(node_data.len(), 1);
+            let node = node_data.get(&1000).expect("offset id 1000 should exist");
+            assert_eq!(node.name, "Remote Node");
+            assert_eq!(node.remote_source.as_deref(), Some("remote"));
+        }
+
+        // A cache-changed notification fired.
+        assert!(cache_changed_rx.try_recv().is_ok());
+        // Drain any further queued notifications from this first poll.
+        while cache_changed_rx.try_recv().is_ok() {}
+
+        // Polling again with identical fixture data changes nothing, so no
+        // further notification should be sent.
+        poll_once(
+            &remote,
+            &network,
+            &tree,
+            &db,
+            &caches,
+            &cache_changed_tx,
+            &mut state,
+        )
+        .await
+        .expect("second poll_once should also succeed");
+        assert!(cache_changed_rx.try_recv().is_err());
+    }
+}

--- a/src/rss.rs
+++ b/src/rss.rs
@@ -121,7 +121,7 @@ impl From<(&TipInfoJson, &Vec<NodeDataJson>)> for Item {
                 if invalid_block.1.len() > 1 { "s" } else { "" },
                 nodes
                     .iter()
-                    .map(|node| format!("{} (id={})", node.name, node.id))
+                    .map(|node| format!("{} (id={})", node.display_name(), node.id))
                     .collect::<Vec<String>>()
                     .join(", "),
             ),
@@ -174,19 +174,23 @@ pub async fn forks_response(
 impl Item {
     pub fn lagging_node_item(node: &NodeDataJson, height: u64) -> Item {
         Item {
-            title: format!("Node '{}' is lagging behind", node.name),
+            title: format!("Node '{}' is lagging behind", node.display_name()),
             description: format!(
                 "The node's active tip is on height {}, while other nodes consider a block with a height at least {} blocks higher their active tip. The node might still be synchronizing with the network or stuck.",
                 height,
                 THREASHOLD_NODE_LAGGING,
             ),
-            guid: format!("lagging-node-{}-on-{}", node.name, height),
+            guid: format!("lagging-node-{}-on-{}", node.display_name(), height),
         }
     }
 
     pub fn unreachable_node_item(node: &NodeDataJson) -> Item {
         Item {
-            title: format!("Node '{}' (id={}) is unreachable", node.name, node.id),
+            title: format!(
+                "Node '{}' (id={}) is unreachable",
+                node.display_name(),
+                node.id
+            ),
             description: format!(
                 "The RPC server of this node is not reachable. The node might be offline or there might be other networking issues. The nodes tip data was last updated at timestamp {} (zero indicates never).",
                 node.last_changed_timestamp,

--- a/src/types.rs
+++ b/src/types.rs
@@ -57,7 +57,7 @@ impl HeaderInfo {
     }
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct NetworkJson {
     pub id: u32,
     pub name: String,
@@ -76,12 +76,12 @@ impl NetworkJson {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct NetworksJsonResponse {
     pub networks: Vec<NetworkJson>,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub struct HeaderInfoJson {
     pub id: usize,
     pub prev_id: usize,
@@ -128,7 +128,7 @@ pub struct InfoJsonResponse {
     pub footer: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct DataJsonResponse {
     pub header_infos: Vec<HeaderInfoJson>,
     pub nodes: Vec<NodeDataJson>,
@@ -161,7 +161,7 @@ pub struct StaleBlocksJsonResponse {
     pub stale_blocks: Vec<StaleBlockJson>,
 }
 
-#[derive(Serialize, Clone, Eq, Hash, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Eq, Hash, PartialEq, Debug)]
 pub struct TipInfoJson {
     pub hash: String,
     pub status: String,
@@ -184,7 +184,7 @@ impl TipInfoJson {
     }
 }
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
 pub struct NodeDataJson {
     pub id: u32,
     pub name: String,
@@ -198,6 +198,14 @@ pub struct NodeDataJson {
     pub version: String,
     /// If the last getchaintips RPC reached the node.
     pub reachable: bool,
+    /// The name of the fork-observer instance this node entry was imported
+    /// from (see `remote_forkobserver`), or `None` for a node configured here.
+    /// Importing skips nodes that already have it set, so a node only ever
+    /// travels one hop from where it's configured. That's what keeps two
+    /// instances pointing at each other from accumulating each other's
+    /// imports.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_source: Option<String>,
 }
 
 impl NodeDataJson {
@@ -217,6 +225,17 @@ impl NodeDataJson {
             last_changed_timestamp,
             version,
             reachable,
+            remote_source: None,
+        }
+    }
+
+    /// The node's name, qualified with the instance it was imported from for
+    /// remote nodes. Used where there's no room for styling (RSS feeds); the
+    /// frontend shows the two parts separately.
+    pub fn display_name(&self) -> String {
+        match &self.remote_source {
+            Some(remote) => format!("{} via {}", self.name, remote),
+            None => self.name.clone(),
         }
     }
 

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -485,6 +485,18 @@ rect.block-miner-bg {
   vertical-align: middle;
 }
 
+/* marks a node imported from another fork-observer instance */
+.nt-via {
+  margin-left: 0.35rem;
+  padding: 0.05rem 0.3rem;
+  font-size: 0.75rem;
+  color: var(--muted-soft);
+  border: 1px solid var(--border-soft);
+  vertical-align: middle;
+  white-space: nowrap;
+  cursor: help;
+}
+
 .nt-desc {
   color: var(--muted-soft);
   font-size: 0.82rem;

--- a/www/js/blocktree.js
+++ b/www/js/blocktree.js
@@ -808,6 +808,14 @@ function get_active_hash_or_fake(node) {
   return "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdead"
 }
 
+// Nodes we didn't fetch ourselves but imported from another fork-observer
+// instance carry that instance's name. Mark them with a muted "via <instance>"
+// so it's clear the data is second-hand.
+function via_label(node) {
+  if (!node.remote_source) return ""
+  return `<span class="nt-via" title="imported from the fork-observer instance '${node.remote_source}'">via ${node.remote_source}</span>`
+}
+
 function ago(timestamp) {
   const rtf = new Intl.RelativeTimeFormat("en", {
     style: "narrow",
@@ -873,6 +881,7 @@ async function draw_nodes() {
         <td class="nt-name">
           <span class="node-status-dot ${d.reachable ? "is-up" : "is-down"}" title="${d.reachable ? "reachable" : "unreachable"}"></span>
           <span class="nt-name-text" title="${d.name}">${d.name}</span>
+          ${via_label(d)}
           ${d.reachable ? "" : "<span class='badge text-bg-danger'>unreachable</span>"}
           ${d.description ? `<div class="nt-desc" onclick="this.classList.toggle('nt-desc-open')">${d.description}</div>` : ""}
         </td>


### PR DESCRIPTION
This adds support for quering a whole fork-observer instance as backend. We show the nodes and the chain of the other instance.

This is useful with multiple deployments of fork-observer with different nodes. Note that nodes are marked as "remote node" to avoid cyclic fetches between two instances.

```toml
[[networks.forkobservers]]
name = "forks.example.com"
description = "other fork-observer instance"
url = "https://forks.example.com/"
network_id = 1
node_id_offset = 1000
```