### PR TITLE
add: show next block based on stratum jobs (stratum.work edition)

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -10,11 +10,14 @@
   --block-top: #e7e9ee;
   --block-side: #c7ccd5;
   --accent: gray;
+  /* what blocks from the stratum feed pulse toward. Deliberately not --accent: that
+     marks minimum-difficulty blocks, and is orange in dark mode. */
+  --mining-pulse: gray;
   --text-color: black;
   --block-to-block-link-color: black;
   --block-description-link-color: gray;
   --block-description-bg: #f8f9fa;
-  --block-miner-color: rgb(122, 122, 122);
+  --block-miner-color: rgb(85, 85, 85);
   --node-indicatior-stroke: black;
 
   --tip-status-color-active: #79FF00;
@@ -36,6 +39,7 @@
     --block-top: #34353c;
     --block-side: #15161a;
     --accent: #f7931a;
+    --mining-pulse: #aab0b8;
     --text-color: white;
     --block-to-block-link-color: white;
     --block-description-link-color: lightgray;
@@ -66,6 +70,7 @@
   --block-top: #34353c;
   --block-side: #15161a;
   --accent: #f7931a;
+  --mining-pulse: #aab0b8;
   --text-color: white;
   --block-to-block-link-color: white;
   --block-description-link-color: lightgray;
@@ -186,6 +191,90 @@ text.block-text {
  fill: var(--text-color);
  text-anchor: middle;
  font-size: 11px;
+}
+
+/* "being mined" blocks (from the stratum jobs feed): a solid block whose whole cube
+   (front + both 3D faces + edges) and its incoming link pulse in unison toward a
+   neutral grey to read as "in progress". Colours (not opacity) are animated so the
+   block stays opaque and the dashed link never shows through it. All parts share the
+   same duration so the pulse looks like one motion. */
+.block.being-mined rect.block-background {
+ animation: mining-pulse-front 2.4s ease-in-out infinite;
+}
+
+.block-back.being-mined polygon.block-face-top {
+ animation: mining-pulse-top 2.4s ease-in-out infinite;
+}
+
+.block-back.being-mined polygon.block-face-side {
+ animation: mining-pulse-side 2.4s ease-in-out infinite;
+}
+
+.block-back.being-mined path.block-edges {
+ animation: mining-pulse-stroke 2.4s ease-in-out infinite;
+}
+
+path.link.link-block-block.being-mined {
+ stroke-opacity: 0.6;
+ animation: mining-pulse-link 2.4s ease-in-out infinite;
+}
+
+@keyframes mining-pulse-front {
+ 0%, 100% { fill: var(--surface-bg); }
+ 50% { fill: color-mix(in srgb, var(--mining-pulse) 32%, var(--surface-bg)); }
+}
+
+@keyframes mining-pulse-top {
+ 0%, 100% { fill: var(--block-top); }
+ 50% { fill: color-mix(in srgb, var(--mining-pulse) 45%, var(--block-top)); }
+}
+
+@keyframes mining-pulse-side {
+ 0%, 100% { fill: var(--block-side); }
+ 50% { fill: color-mix(in srgb, var(--mining-pulse) 45%, var(--block-side)); }
+}
+
+@keyframes mining-pulse-stroke {
+ 0%, 100% { stroke: var(--block-stroke); }
+ 50% { stroke: var(--mining-pulse); }
+}
+
+@keyframes mining-pulse-link {
+ 0%, 100% { stroke: var(--block-to-block-link-color); }
+ 50% { stroke: var(--mining-pulse); }
+}
+
+/* status tag below a block that comes from the stratum feed. Unlike the tip-status
+   boxes - whose fill is a bright per-status colour, so they can carry dark text in
+   either theme - this one has no colour of its own, so it takes the same surface and
+   muted label colours as the pool names it sits among. */
+.mining-tag-bg {
+ fill: var(--surface-bg);
+ stroke: var(--block-stroke);
+ stroke-width: 0.5px;
+}
+
+.mining-tag-text {
+ fill: var(--block-miner-color);
+ font-size: 8px;
+}
+
+/* force-positioned pool-name labels around a being-mined block */
+.mining-pool-link {
+ stroke: var(--block-stroke);
+ stroke-width: 1px;
+ opacity: 0.5;
+}
+
+.mining-pool-bg {
+ fill: var(--surface-bg);
+ stroke: var(--block-stroke);
+ stroke-width: 0.5px;
+}
+
+.mining-pool-text {
+ fill: var(--block-miner-color);
+ font-size: 8px;
 }
 
 text.block-miner {

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -39,7 +39,7 @@
     --block-top: #34353c;
     --block-side: #15161a;
     --accent: #f7931a;
-    --mining-pulse: #aab0b8;
+    --mining-pulse: #555;
     --text-color: white;
     --block-to-block-link-color: white;
     --block-description-link-color: lightgray;
@@ -70,7 +70,7 @@
   --block-top: #34353c;
   --block-side: #15161a;
   --accent: #f7931a;
-  --mining-pulse: #aab0b8;
+  --mining-pulse: #555;
   --text-color: white;
   --block-to-block-link-color: white;
   --block-description-link-color: lightgray;
@@ -244,7 +244,7 @@ path.link.link-block-block.being-mined {
  50% { stroke: var(--mining-pulse); }
 }
 
-/* status tag below a block that comes from the stratum feed. Unlike the tip-status
+/* status tag above a block that comes from the stratum feed. Unlike the tip-status
    boxes - whose fill is a bright per-status colour, so they can carry dark text in
    either theme - this one has no colour of its own, so it takes the same surface and
    muted label colours as the pool names it sits among. */

--- a/www/js/blocktree.js
+++ b/www/js/blocktree.js
@@ -99,6 +99,27 @@ let lastTipPos = { x: 0, y: 0 }
 // See the end of draw().
 let viewAnchor = null
 
+// Blocks that come from the stratum jobs feed rather than from our own nodes: the one
+// being mined, and the one that was just found and that pools are already building on.
+// Both are drawn the same way - solid and pulsing - and only their tag tells them
+// apart. Drawing them solid also keeps the links from showing through the block.
+// The keys are the statuses build_mining_headers() gives those blocks.
+const MINING_TAGS = {
+  "mining": {
+    text: "being mined",
+    title: () => "Pools are working on this block right now, according to the stratum jobs feed.",
+  },
+  "just-found": {
+    text: "just found",
+    title: d => "Pools are already mining on top of block " + d.data.data.real_hash +
+      ", so it exists — but none of our nodes have reported it yet.",
+  },
+}
+
+function from_stratum_feed(header) {
+  return header.status in MINING_TAGS
+}
+
 // size a group's background rect to fit the text next to it, with `px`/`py` of padding.
 // Both are only measurable once the text has been laid out, hence the getBBox().
 function fit_rect_to_text(group, px, py) {
@@ -200,10 +221,16 @@ let countdownLayer = g
 let miningDrawCtx = null
 
 // invert the current stratum jobs (state_stratum_jobs, one entry per pool, kept up to
-// date in main.js) into a map of prev_hash -> { parent, pool_names }: the pools mining
-// on each block we recognise. Expired pools are pruned here so the set stays current
+// date in main.js) into a map of prev_hash -> { parent, just_found, pool_names }: the
+// pools mining on each block. Expired pools are pruned here so the set stays current
 // without a separate timer.
-function current_mining_by_prev(header_infos) {
+//
+// `parent` is the header the to-be-mined block hangs off. Normally that is the block
+// the pools name in their job. When we don't know that block it is our tip instead, and
+// `just_found` says a stand-in for the block the feed told us about goes in between:
+// that happens for a few seconds after every block, because pools hear about it through
+// their own infrastructure well before a node has received, validated and relayed it.
+function current_mining_by_prev(header_infos, max_height) {
   let result = new Map()
   if (!MINING_ENABLED || state_stratum_jobs.size === 0) {
     return result
@@ -212,6 +239,8 @@ function current_mining_by_prev(header_infos) {
   // index the real headers by hash so we can resolve a job's parent block
   let by_hash = new Map()
   header_infos.forEach(h => by_hash.set(h.hash, h))
+  // the block every job builds on sits one below the height being mined
+  let tip = header_infos.filter(h => h.height == max_height)[0]
 
   state_stratum_jobs.forEach((job, pool_name) => {
     // drop pools we haven't heard from in a while
@@ -219,12 +248,19 @@ function current_mining_by_prev(header_infos) {
       state_stratum_jobs.delete(pool_name)
       return
     }
-    // only show to-be-mined blocks that build on a block we actually know about
     let parent = by_hash.get(job.prev_hash)
-    if (parent === undefined) return
+    // A parent we don't know is only worth drawing when the feed places it exactly one
+    // block past our tip, i.e. it is the block that was just found. Anything further
+    // ahead (or behind) would mean speculating about a chain we know nothing about, so
+    // those jobs are dropped.
+    let just_found = parent === undefined && tip !== undefined && job.height == max_height + 2
+    if (parent === undefined && !just_found) return
+    // the pair then hangs off our tip, with the stand-in block in between
+    if (just_found) parent = tip
+
     let entry = result.get(job.prev_hash)
     if (entry === undefined) {
-      entry = { parent, pool_names: [] }
+      entry = { parent, just_found, pool_names: [] }
       result.set(job.prev_hash, entry)
     }
     entry.pool_names.push(pool_name)
@@ -234,26 +270,47 @@ function current_mining_by_prev(header_infos) {
   return result
 }
 
-// build synthetic "being mined" header objects to inject into the tree. One
-// to-be-mined block per prev_hash we recognise, aggregating all pools mining on it.
-function build_mining_headers(header_infos) {
+// build synthetic header objects to inject into the tree: one to-be-mined block per
+// prev_hash, aggregating all pools mining on it, plus - for pools that have already
+// moved on to a block we haven't seen - a "just found" block standing in for it, so
+// the to-be-mined block has something to hang off.
+function build_mining_headers(header_infos, max_height) {
   let mining_headers = []
-  current_mining_by_prev(header_infos).forEach(({ parent, pool_names }, prev_hash) => {
-    mining_headers.push({
-      id: "mining-" + prev_hash,
-      prev_id: parent.id,
-      height: parent.height + 1,
-      hash: "mining-" + prev_hash,
-      prev_blockhash: prev_hash,
-      // pool names are shown in a force-positioned cloud around the block, so the
-      // block itself carries no miner label
-      miner: "",
-      // not MIN_DIFFICULTY, so it doesn't get the accent-colored stroke
-      difficulty_int: 0,
-      status: "mining",
-      mining_pools: pool_names,
+  current_mining_by_prev(header_infos, max_height)
+    .forEach(({ parent, just_found, pool_names }, prev_hash) => {
+      if (just_found) {
+        // The feed gave us this block's real hash, kept in real_hash. The `hash` used
+        // for identity is prefixed so it can't collide with the real header once a node
+        // reports it: the blocks are keyed by hash, and sharing a key would morph this
+        // one into the real block while leaving its "not seen yet" styling behind.
+        // With a distinct key it is simply removed and the real block drawn instead.
+        mining_headers.push({
+          id: "found-" + prev_hash,
+          prev_id: parent.id,
+          height: parent.height + 1,
+          hash: "found-" + prev_hash,
+          real_hash: prev_hash,
+          prev_blockhash: parent.hash,
+          miner: "",
+          difficulty_int: 0,
+          status: "just-found",
+        })
+      }
+      mining_headers.push({
+        id: "mining-" + prev_hash,
+        prev_id: just_found ? "found-" + prev_hash : parent.id,
+        height: parent.height + (just_found ? 2 : 1),
+        hash: "mining-" + prev_hash,
+        prev_blockhash: prev_hash,
+        // pool names are shown in a force-positioned cloud around the block, so the
+        // block itself carries no miner label
+        miner: "",
+        // not MIN_DIFFICULTY, so it doesn't get the accent-colored stroke
+        difficulty_int: 0,
+        status: "mining",
+        mining_pools: pool_names,
+      })
     })
-  })
   return mining_headers
 }
 
@@ -268,7 +325,7 @@ function refresh_mining() {
     draw({ preserveView: true, reason: "jobs (first draw)" })
     return
   }
-  let desired = current_mining_by_prev(state_data.header_infos)
+  let desired = current_mining_by_prev(state_data.header_infos, miningDrawCtx.max_height)
   let current_keys = miningDrawCtx.toBeMinedByPrev
   let same = desired.size === current_keys.size &&
     Array.from(desired.keys()).every(k => current_keys.has(k))
@@ -312,10 +369,11 @@ function preprocess_data(data) {
     header_info.is_tip = status != undefined
   })
 
-  // synthetic "being mined" blocks from the stratum jobs feed, injected as children
-  // of the block each pool builds on. max_height (below) stays based on the real
-  // headers only, so these are not treated as the animated newest block.
-  let mining_headers = build_mining_headers(header_infos)
+  // synthetic blocks from the stratum jobs feed, injected as children of the block
+  // each pool builds on. max_height stays based on the real headers only, so these are
+  // not treated as the animated newest block.
+  const max_height = Math.max(...header_infos.map(d => d.height))
+  let mining_headers = build_mining_headers(header_infos, max_height)
 
   var treeData = d3
     .stratify()
@@ -369,7 +427,7 @@ function preprocess_data(data) {
   // sliding back and forth for no visible reason. Both runs walk the same stripped
   // tree, so every real block is in both and htoi above stays valid for either.
   const real_root = treemap(
-    d3.hierarchy(treeData, d => (d.children || []).filter(c => c.data.status != "mining"))
+    d3.hierarchy(treeData, d => (d.children || []).filter(c => !from_stratum_feed(c.data)))
       .sort(sort_blocks))
   let real_x = new Map()
   real_root.descendants().forEach(d => real_x.set(d.data.data.hash, d.x))
@@ -385,7 +443,6 @@ function preprocess_data(data) {
     shift.set(d, s)
     d.x += s
   })
-  const max_height = Math.max(...header_infos.map(d => d.height))
 
   return [root_node, max_height, htoi]
 }
@@ -421,7 +478,7 @@ function draw(opts) {
       enter => {
         let back = enter.append("g")
           .attr("class", "block-back")
-          .classed("being-mined", d => d.data.data.status == "mining")
+          .classed("being-mined", d => from_stratum_feed(d.data.data))
           .attr("transform", d => "translate(" + o.x(d, htoi) + "," + o.y(d, htoi) + ")")
         const half = BLOCK_SIZE / 2
         const DEPTH = BLOCK_DEPTH
@@ -459,7 +516,7 @@ function draw(opts) {
           .attr("fill", "transparent")
           .attr("stroke-dashoffset", (d, x, y) => y[x].getTotalLength())
           .attr("stroke-opacity", 1)
-          .classed("being-mined", d => d.target.data.data.status == "mining")
+          .classed("being-mined", d => from_stratum_feed(d.target.data.data))
           .transition(d3.transition().duration(300))
           .attr("stroke-dashoffset", 0)
           .attr("stroke-opacity", 0.2)
@@ -509,7 +566,7 @@ function draw(opts) {
       enter => {
         let newBlocks = enter.append("g")
           .classed("block", true)
-          .classed("being-mined", d => d.data.data.status == "mining")
+          .classed("being-mined", d => from_stratum_feed(d.data.data))
           .attr("id", d => "block-" + d.data.data.height + "-" + d.data.data.hash)
           .attr("transform", d => "translate(" + o.x(d, htoi) + "," + o.y(d, htoi) + ")")
           .attr("x", d => o.x(d, htoi))
@@ -525,7 +582,7 @@ function draw(opts) {
           .attr("stroke-width", d => d.data.data.difficulty_int == MIN_DIFFICULTY ? 3 : 1)
           .attr("stroke-linejoin", "round")
           .attr("stroke-opacity", 1)
-          .classed("being-mined", d => d.data.data.status == "mining")
+          .classed("being-mined", d => from_stratum_feed(d.data.data))
 
         block_backgrounds.filter(d => d.data.data.height != max_height || initialDraw)
           .attr("x", -BLOCK_SIZE/2)
@@ -553,16 +610,18 @@ function draw(opts) {
           .classed("block-miner", true)
           .text(d => d.data.data.miner.length > 14 ? d.data.data.miner.substring(0, 14) + "…" : d.data.data.miner);
 
-        // "being mined" tag above to-be-mined blocks, styled like the tip-status boxes so it
-        // reads as a status label. Lives in the block group, so it persists (and isn't
-        // re-rendered) on the frequent pool-only refreshes.
-        let mining_tag = block_child_group.filter(d => d.data.data.status == "mining")
+        // status tag below the blocks that come from the stratum feed, styled like the
+        // tip-status boxes so it reads as a status label. Lives in the block group, so
+        // it persists (and isn't re-rendered) on the frequent pool-only refreshes.
+        let mining_tag = block_child_group.filter(d => d.data.data.status in MINING_TAGS)
           .append("g")
-          .attr("class", "mining-tag")
+          .attr("class", d => "mining-tag mining-tag-" + d.data.data.status)
           .attr("transform", "translate(" + -BLOCK_SIZE/2 + "," + (+(BLOCK_SIZE / 2) + BLOCK_DEPTH) + ")")
         mining_tag.append("rect").attr("class", "mining-tag-bg")
         mining_tag.append("text").attr("class", "mining-tag-text")
-          .attr("text-anchor", "left").attr("dy", ".35em").text("being mined..")
+          .attr("text-anchor", "left").attr("dy", ".35em")
+          .text(d => MINING_TAGS[d.data.data.status].text)
+          .append("title").text(d => MINING_TAGS[d.data.data.status].title(d))
         mining_tag.each(function () { fit_rect_to_text(d3.select(this), 1, 1) })
 
         if (!initialDraw) {
@@ -620,7 +679,7 @@ function draw(opts) {
   let toBeMinedByPrev = new Map()
   root_node.descendants().filter(d => d.data.data.status == "mining")
     .forEach(d => toBeMinedByPrev.set(d.data.data.prev_blockhash, d))
-  miningDrawCtx = { root_node, htoi, toBeMinedByPrev }
+  miningDrawCtx = { root_node, htoi, max_height, toBeMinedByPrev }
 
   // size the miner background box to fit its (already positioned) text
   recalc_miner_boxes()
@@ -629,7 +688,7 @@ function draw(opts) {
   // whole group is rotated like the miner text so it sits on the opposite side.
   let node_groups = g
     .selectAll(".tip-info")
-    .data(root_node.descendants().filter(d => d.data.data.status != "in-chain" && d.data.data.status != "mining"),
+    .data(root_node.descendants().filter(d => d.data.data.status != "in-chain" && !from_stratum_feed(d.data.data)),
       d => `${d.data.data.hash}-${d.data.data.height}`)
     .join("g")
     .classed("tip-info", true)
@@ -1087,8 +1146,8 @@ function onBlockClick(c, d) {
   let blockGroup = d3.select(c.target.parentElement.parentElement)
   // only react to clicks on an actual block group
   if (blockGroup.attr("class") == null || !blockGroup.attr("class").startsWith("block")) return
-  // to-be-mined blocks have no real header data to show in the info card
-  if (d.data.data.status == "mining") return
+  // blocks that only come from the stratum feed have no header data for the info card
+  if (from_stratum_feed(d.data.data)) return
 
   // toggle: if this block already has an open description, close it
   let existing = descLayer.selectAll(".block-description")

--- a/www/js/blocktree.js
+++ b/www/js/blocktree.js
@@ -8,6 +8,7 @@ const orientationSelect = d3.select("#orientation")
 
 const orientations = {
   "bottom-to-top": {
+    name: "bottom-to-top",
     x: (d, _) => d.x,
     y: (d, htoi) => -htoi[d.data.data.height] * NODE_SIZE,
     // start the link half a depth beyond the parent's top edge, over the middle of
@@ -24,6 +25,8 @@ const orientations = {
     // where the tip block should land in the viewport on the initial draw: the chain
     // grows downward, so put the tip near the top to show less empty space.
     tip_anchor: (w, h) => [w/2, h*0.25],
+    // one block slot further along the chain, i.e. where the next block will appear
+    next_slot: {x: 0, y: -NODE_SIZE},
     // the along-chain axis is y (growing negative), so the countdown marker is a
     // horizontal line at a fixed y spanning the cross axis (x).
     countdown_along: (idx) => -idx * NODE_SIZE,
@@ -31,6 +34,7 @@ const orientations = {
     countdown_label_pos: (along, cross_min) => ({x: cross_min, y: along}),
   },
   "left-to-right": {
+    name: "left-to-right",
     x: (d, htoi) => htoi[d.data.data.height] * NODE_SIZE,
     y: (d, _) => d.x,
     // start the link half a depth beyond the parent's right edge, over the middle of
@@ -46,6 +50,8 @@ const orientations = {
     // where the tip block should land in the viewport on the initial draw: the chain
     // grows rightward, so put the tip near the right to show less empty space.
     tip_anchor: (w, h) => [w*0.75, h/2],
+    // one block slot further along the chain, i.e. where the next block will appear
+    next_slot: {x: NODE_SIZE, y: 0},
     // the along-chain axis is x, so the countdown marker is a vertical line at a
     // fixed x spanning the cross axis (y).
     countdown_along: (idx) => idx * NODE_SIZE,
@@ -86,13 +92,71 @@ let o = orientations["left-to-right"];
 // bring the view back to it after the user pans/zooms away
 let lastTipPos = { x: 0, y: 0 }
 
+// what the camera is currently anchored on: the tip hash it points at, plus the
+// orientation that tip was laid out in. Null before the first draw. This is
+// deliberately not the same as lastTipPos: the camera only follows when there is
+// genuinely something else to look at, not on every change of the point we focus on.
+// See the end of draw().
+let viewAnchor = null
+
+// whether the mining feature is on (?mining, see main.js). blocktree.js is loaded
+// first, so guard against the constant not being there at all.
+function mining_enabled() {
+  return typeof MINING_ENABLED !== "undefined" && MINING_ENABLED
+}
+
+// size a group's background rect to fit the text next to it, with `px`/`py` of padding.
+// Both are only measurable once the text has been laid out, hence the getBBox().
+function fit_rect_to_text(group, px, py) {
+  let bb = group.select("text").node().getBBox()
+  group.select("rect")
+    .attr("x", bb.x - px).attr("y", bb.y - py)
+    .attr("width", bb.width + 2 * px).attr("height", bb.height + 2 * py)
+}
+
+// TEMPORARY: logging for the "the view keeps moving" bug. Two different things read as
+// the view moving: the camera panning, and the blocks sliding underneath a camera that
+// stayed put. Both are logged, so a jump can be attributed to one or the other.
+// Remove this (and its call sites) once the bug is understood.
+const VIEW_DEBUG = true
+function log_view(what, info) {
+  if (VIEW_DEBUG) console.log("[view] " + what, info)
+}
+
+// positions of the real blocks at the last draw, to detect the layout shifting under
+// the camera. Part of the TEMPORARY logging above.
+let lastBlockPos = new Map()
+function log_layout_shift(root_node, htoi) {
+  if (!VIEW_DEBUG) return
+  let now = new Map(), moved = [], max = 0
+  root_node.descendants().forEach(d => {
+    let key = d.data.data.hash
+    let pos = [o.x(d, htoi), o.y(d, htoi)]
+    now.set(key, pos)
+    let was = lastBlockPos.get(key)
+    if (was === undefined) return
+    let dx = pos[0] - was[0], dy = pos[1] - was[1]
+    if (dx || dy) {
+      moved.push({ h: d.data.data.height, status: d.data.data.status, dx, dy })
+      max = Math.max(max, Math.abs(dx), Math.abs(dy))
+    }
+  })
+  lastBlockPos = now
+  if (moved.length) log_view("layout shifted", { count: moved.length, max, moved: moved.slice(0, 8) })
+}
+
 let svg = d3
     .select("#drawing-area")
 
 let initialDraw = true
 
 // enables zoom and panning
-const zoom = d3.zoom().scaleExtent([0.15, 5]).on( "zoom", e => {
+const zoom = d3.zoom().scaleExtent([0.15, 5])
+  // interpolate transitions in a straight line. d3's default (interpolateZoom) flies
+  // the camera along an arc that zooms out and back in again, which for the short
+  // pans we do here reads as the view lurching away and returning.
+  .interpolate(d3.interpolate)
+  .on( "zoom", e => {
   g.attr("transform", e.transform)
   // re-measure the text-fitted boxes; their metrics can be stale if they were first
   // sized before the text was fully laid out
@@ -110,6 +174,19 @@ let g = svg
 let connectorLayer = g
     .append("g")
     .attr("id", "description-connectors")
+
+// layer for the connector lines from a being-mined block to its pool labels. Like
+// connectorLayer it is never raised, so the lines stay below the blocks and appear to
+// come out from behind the to-be-mined block.
+let miningLinkLayer = g
+    .append("g")
+    .attr("id", "mining-links")
+
+// layer for the force-positioned pool-name labels around "being mined" blocks. It is
+// raised above the blocks on every draw so the labels stay readable.
+let miningLabelLayer = g
+    .append("g")
+    .attr("id", "mining-labels")
 
 // overlay layer that always holds the open block descriptions (info boxes). It is
 // raised to the top on every draw so the boxes are never painted over by blocks or
@@ -196,7 +273,8 @@ function preprocess_data(data) {
   return [root_node, max_height, htoi]
 }
 
-function draw() {
+function draw(opts) {
+  opts = opts || {}
   let data = state_data
 
   // nothing to draw if there are no headers
@@ -205,6 +283,16 @@ function draw() {
   }
 
   const [root_node, max_height, htoi] = preprocess_data(data)
+
+  log_layout_shift(root_node, htoi)
+
+  // An orientation switch moves every block into a different coordinate space, tens of
+  // thousands of pixels away. Animating that flies the camera - and slides the blocks -
+  // through empty space for the better part of a second, which just reads as the view
+  // having gone blank. So a switch snaps into place instead, the way the first draw
+  // does; there is no continuity between the two layouts to preserve anyway.
+  const snap = initialDraw || !!opts.snap
+  const move = (sel, ms) => snap ? sel : sel.transition(d3.transition().duration(ms))
 
   // the 3D extrusion (top + right faces) lives in its own layer below the links, so
   // a link can pass over a block's depth and tuck behind its front face — making it
@@ -216,6 +304,7 @@ function draw() {
       enter => {
         let back = enter.append("g")
           .attr("class", "block-back")
+          .classed("being-mined", d => d.data.data.status == "mining")
           .attr("transform", d => "translate(" + o.x(d, htoi) + "," + o.y(d, htoi) + ")")
         const half = BLOCK_SIZE / 2
         const DEPTH = BLOCK_DEPTH
@@ -234,7 +323,7 @@ function draw() {
         return back
       },
       update => {
-        update.transition(d3.transition().duration(600))
+        move(update, 600)
           .attr("transform", d => "translate(" + o.x(d, htoi) + "," + o.y(d, htoi) + ")")
         return update
       }
@@ -261,8 +350,7 @@ function draw() {
           .attr("stroke-opacity", 1)
       },
       update => {
-        update
-          .transition(d3.transition().duration(600))
+        move(update, 600)
           .attr("d", o.linkDir(htoi))
           .attr("stroke-dasharray", (d, x, y) => d.target.data.data.height - d.source.data.data.height == 1 ? y[x].getTotalLength() + " "  + y[x].getTotalLength() : "4 5")
           .attr("stroke-dashoffset", 0)
@@ -289,8 +377,7 @@ function draw() {
         return blocksNotShown
       },
       update => {
-        update
-          .transition(d3.transition().duration(600))
+        move(update, 600)
           .attr("x", d => hidden_text_x(d, htoi))
           .attr("y", d => hidden_text_y(d, htoi))
           .attr("transform", d => `rotate(${o.block_text_rotate}, ${hidden_text_x(d, htoi)},${hidden_text_y(d, htoi)})`)
@@ -305,6 +392,7 @@ function draw() {
       enter => {
         let newBlocks = enter.append("g")
           .classed("block", true)
+          .classed("being-mined", d => d.data.data.status == "mining")
           .attr("id", d => "block-" + d.data.data.height + "-" + d.data.data.hash)
           .attr("transform", d => "translate(" + o.x(d, htoi) + "," + o.y(d, htoi) + ")")
           .attr("x", d => o.x(d, htoi))
@@ -319,7 +407,7 @@ function draw() {
           .attr("stroke", d => d.data.data.difficulty_int == MIN_DIFFICULTY ? "var(--accent)" : "var(--block-stroke)")
           .attr("stroke-width", d => d.data.data.difficulty_int == MIN_DIFFICULTY ? 3 : 1)
           .attr("stroke-linejoin", "round")
-          .attr("stroke-opacity", d => d.data.data.status == "mining" ? 0.2 : 1)
+          .attr("stroke-opacity", 1)
           .classed("being-mined", d => d.data.data.status == "mining")
 
         block_backgrounds.filter(d => d.data.data.height != max_height || initialDraw)
@@ -348,6 +436,18 @@ function draw() {
           .classed("block-miner", true)
           .text(d => d.data.data.miner.length > 14 ? d.data.data.miner.substring(0, 14) + "…" : d.data.data.miner);
 
+        // "being mined" tag above to-be-mined blocks, styled like the tip-status boxes so it
+        // reads as a status label. Lives in the block group, so it persists (and isn't
+        // re-rendered) on the frequent pool-only refreshes.
+        let mining_tag = block_child_group.filter(d => d.data.data.status == "mining")
+          .append("g")
+          .attr("class", "mining-tag")
+          .attr("transform", "translate(" + -BLOCK_SIZE/2 + "," + (+(BLOCK_SIZE / 2) + BLOCK_DEPTH) + ")")
+        mining_tag.append("rect").attr("class", "mining-tag-bg")
+        mining_tag.append("text").attr("class", "mining-tag-text")
+          .attr("text-anchor", "left").attr("dy", ".35em").text("being mined..")
+        mining_tag.each(function () { fit_rect_to_text(d3.select(this), 1, 1) })
+
         if (!initialDraw) {
           block_backgrounds
             .filter(d => d.data.data.height == max_height)
@@ -375,8 +475,7 @@ function draw() {
         return newBlocks
       },
       update => {
-        update
-          .transition(d3.transition().duration(600))
+        move(update, 600)
           .attr("transform", d => "translate(" + o.x(d, htoi) + "," + o.y(d, htoi) + ")")
         // keep the stored anchor coordinates in sync (info boxes read these), or
         // they'd stay at the previous orientation's position after a switch
@@ -391,6 +490,13 @@ function draw() {
         return update
       }
     );
+
+  // pool names orbiting each "being mined" block, laid out with a force simulation
+  if (opts.clearPoolCloud) {
+    clear_mining_pool_clouds()
+  } else {
+    draw_mining_pool_clouds(root_node, htoi)
+  }
 
   // size the miner background box to fit its (already positioned) text
   recalc_miner_boxes()
@@ -429,10 +535,22 @@ function draw() {
 
   let offset_x = 0;
   let offset_y = 0;
-  let max_height_tip = root_node.leaves().filter(d => d.data.data.height == max_height)[0]
+  // the real tip at max_height. Not necessarily a leaf(): a to-be-mined block is
+  // injected as its child, so filter descendants by height instead of using leaves().
+  let max_height_tip = root_node.descendants().filter(d => d.data.data.status != "mining" && d.data.data.height == max_height)[0]
   if (max_height_tip !== undefined) {
     offset_x = o.x(max_height_tip, htoi);
     offset_y = o.y(max_height_tip, htoi);
+    // With the mining feature on, center one slot past the tip - where the to-be-mined
+    // block sits (and where the next block will appear) - so it and its pool cloud are
+    // in view. This deliberately depends only on the mode, not on whether a to-be-mined
+    // block happens to exist right now: pools switch jobs constantly, so anchoring on
+    // the block itself dragged the view back and forth by a block slot as it came and
+    // went.
+    if (mining_enabled()) {
+      offset_x += o.next_slot.x;
+      offset_y += o.next_slot.y;
+    }
   }
 
   draw_countdown(htoi, max_height, root_node)
@@ -446,6 +564,7 @@ function draw() {
   blocks.raise()
   node_groups.raise()
   countdownLayer.raise()
+  miningLabelLayer.raise()
 
   // keep open descriptions (and their connectors) anchored to their block as the
   // layout shifts, and raise the overlay so the info boxes stay on top of everything
@@ -468,16 +587,37 @@ function draw() {
 
   lastTipPos = { x: offset_x, y: offset_y }
 
-  zoom.scaleBy(svg, 1);
-  let svgSize = d3.select("#drawing-area").node().getBoundingClientRect();
-  zoom.translateTo(svg.transition(d3.transition().duration(initialDraw ? 0 : 750)), offset_x, offset_y, o.tip_anchor(svgSize.width, svgSize.height))
+  // Panning the camera is disruptive, so only do it when there is genuinely something
+  // else to look at: a new tip, a reorg, or a switch of orientation - which moves every
+  // block into a different coordinate space and would otherwise leave the camera
+  // pointing at empty space.
+  let tip_hash = max_height_tip === undefined ? null : max_height_tip.data.data.hash
+  let anchor = tip_hash + "|" + o.name
+  let follow = initialDraw || viewAnchor === null || viewAnchor != anchor
 
-  initialDraw = false
+  log_view("draw", {
+    reason: opts.reason || "?",
+    orientation: o.name,
+    tip: tip_hash && tip_hash.substring(56),
+    max_height,
+    offset: [offset_x, offset_y],
+    viewAnchor, anchor, follow,
+  })
+
+  if (follow) {
+    viewAnchor = anchor
+    zoom.scaleBy(svg, 1);
+    let svgSize = d3.select("#drawing-area").node().getBoundingClientRect();
+    zoom.translateTo(svg.transition(d3.transition().duration(snap ? 0 : 750)), offset_x, offset_y, o.tip_anchor(svgSize.width, svgSize.height))
+    initialDraw = false
+  }
 }
 
-// bring the view back to the tip, anchored where the initial draw placed it. Keeps
-// the current zoom level; just re-pans.
+// bring the view back to whatever the last draw focused on (the tip, or the block
+// being mined on top of it), anchored where the initial draw placed it. Keeps the
+// current zoom level; just re-pans.
 function recenter() {
+  log_view("recenter", { to: lastTipPos, orientation: o.name })
   let svgSize = d3.select("#drawing-area").node().getBoundingClientRect();
   zoom.translateTo(svg.transition(d3.transition().duration(500)), lastTipPos.x, lastTipPos.y, o.tip_anchor(svgSize.width, svgSize.height))
 }
@@ -486,6 +626,163 @@ function recenter() {
 function closeAllDescriptions() {
   descLayer.selectAll(".block-description").remove()
   connectorLayer.selectAll(".link-block-description").remove()
+}
+
+// radius of the ring the labels are pulled toward, around the block centre
+const MINING_CLOUD_RADIUS = BLOCK_SIZE * 3
+
+// persistent force layout for the pool-name clouds. Kept across redraws so labels keep
+// their positions (and keep gently drifting) instead of teleporting each frame.
+let miningSim = null
+let miningLabelNodes = new Map() // key -> { key, name, bx, by, x, y }
+// which labels, around which blocks, the simulation was last reheated for
+let miningCloudKey = null
+
+// pull each label toward a ring of `radius` around ITS OWN block centre (bx, by).
+// d3.forceRadial only supports one shared centre, so we roll our own.
+function forcePerNodeRadial(radius, strength) {
+  let nodes
+  function force(alpha) {
+    for (const d of nodes) {
+      const dx = d.x - d.bx, dy = d.y - d.by
+      const r = Math.sqrt(dx * dx + dy * dy) || 1e-6
+      const k = (radius - r) * strength * alpha / r
+      d.vx += dx * k
+      d.vy += dy * k
+    }
+  }
+  force.initialize = n => { nodes = n }
+  return force
+}
+
+// push labels away from block centres so they don't sit on top of older blocks
+function forceAvoidBlocks(blocks, minDist, strength) {
+  let nodes
+  function force(alpha) {
+    for (const d of nodes) {
+      for (const b of blocks) {
+        const dx = d.x - b.x, dy = d.y - b.y
+        const dist = Math.sqrt(dx * dx + dy * dy) || 1e-6
+        if (dist < minDist) {
+          const k = (minDist - dist) * strength * alpha / dist
+          d.vx += dx * k
+          d.vy += dy * k
+        }
+      }
+    }
+  }
+  force.initialize = n => { nodes = n }
+  return force
+}
+
+// tick handler: move the labels and their connector lines to the simulation positions
+function mining_cloud_tick() {
+  miningLinkLayer.selectAll("line.mining-pool-link")
+    .attr("x1", d => d.bx).attr("y1", d => d.by)
+    .attr("x2", d => d.x).attr("y2", d => d.y)
+  miningLabelLayer.selectAll("g.mining-pool")
+    .attr("transform", d => "translate(" + d.x + "," + d.y + ")")
+}
+
+// throw the pool-name cloud away. The labels are held in place by a running force
+// simulation in the coordinates of the orientation they were laid out in, so carrying
+// them over to another one sends them flying across the viewport. Jobs arrive several
+// times a second, so the cloud is rebuilt almost immediately - seeded fresh around its
+// block in the new orientation.
+function clear_mining_pool_clouds() {
+  if (miningSim) miningSim.stop()
+  miningLabelNodes = new Map()
+  miningCloudKey = null
+  miningLinkLayer.selectAll("line.mining-pool-link").remove()
+  miningLabelLayer.selectAll("g.mining-pool").remove()
+}
+
+// lay out each being-mined block's pool names in a live force cloud around it:
+// repulsion + collision keep names apart, a per-node radial pull keeps them ringed
+// around their block, and a repelling force keeps them off the other blocks. Node
+// objects persist across redraws so positions are continuous, and the simulation is
+// gently reheated each draw so the labels keep drifting.
+function draw_mining_pool_clouds(root_node, htoi) {
+  let mining_nodes = root_node.descendants().filter(d => d.data.data.status == "mining")
+
+  // obstacles: every real block centre, for the avoid force
+  let obstacles = root_node.descendants()
+    .filter(d => d.data.data.status != "mining")
+    .map(d => ({ x: o.x(d, htoi), y: o.y(d, htoi) }))
+
+  // resolve the desired labels into persistent node objects (keyed by block + name)
+  let wanted = new Map()
+  mining_nodes.forEach(node => {
+    const cx = o.x(node, htoi), cy = o.y(node, htoi)
+    // every pool mining on this block gets its own label, however many there are
+    const labels = node.data.data.mining_pools
+    const n = labels.length
+    labels.forEach((name, i) => {
+      const key = node.data.data.hash + "|" + name
+      let d = miningLabelNodes.get(key)
+      if (d === undefined) {
+        // seed a new label on the ring near its block so it eases into place
+        const a = (i / n) * 2 * Math.PI
+        d = { key, x: cx + MINING_CLOUD_RADIUS * Math.cos(a), y: cy + MINING_CLOUD_RADIUS * Math.sin(a) }
+      }
+      d.name = name
+      d.bx = cx
+      d.by = cy
+      wanted.set(key, d)
+    })
+  })
+  miningLabelNodes = wanted
+  let nodeArray = Array.from(wanted.values())
+
+  // connector lines (in the lower layer, so they come out from behind the block) and
+  // label groups, keyed so they persist across draws
+  miningLinkLayer.selectAll("line.mining-pool-link")
+    .data(nodeArray, d => d.key)
+    .join(enter => enter.append("line").attr("class", "mining-pool-link"))
+
+  miningLabelLayer.selectAll("g.mining-pool")
+    .data(nodeArray, d => d.key)
+    .join(enter => {
+      let group = enter.append("g").attr("class", "mining-pool")
+      group.append("rect").attr("class", "mining-pool-bg")
+      group.append("text").attr("class", "mining-pool-text")
+        .attr("text-anchor", "middle").attr("dy", ".35em")
+      return group
+    })
+
+  // (re)set label text and size the background to fit it (names can change)
+  miningLabelLayer.selectAll("g.mining-pool").each(function (d) {
+    let group = d3.select(this)
+    group.select("text").text(d.name)
+    fit_rect_to_text(group, 3, 1)
+  })
+
+  if (nodeArray.length == 0) {
+    if (miningSim) miningSim.stop()
+    return
+  }
+
+  const char_w = 5.2 // rough width per character at 8px, for collision sizing
+  if (miningSim === null) {
+    miningSim = d3.forceSimulation().on("tick", mining_cloud_tick)
+  }
+  miningSim.nodes(nodeArray)
+  miningSim
+    .force("charge", d3.forceManyBody().strength(-20))
+    .force("collide", d3.forceCollide().radius(d => (d.name.length * char_w) / 2 + 7))
+    .force("radial", forcePerNodeRadial(MINING_CLOUD_RADIUS, 0.12))
+    .force("avoid", forceAvoidBlocks(obstacles, BLOCK_SIZE * 3, 0.6))
+  // Gentle reheat so labels drift into place rather than snapping - but only when the
+  // cloud actually changed. Jobs arrive several times a second and mostly just repeat
+  // what we already draw; reheating on every one of them kept the labels permanently
+  // in motion instead of letting them come to rest.
+  let cloud_key = nodeArray.map(d => d.key + "@" + d.bx + "," + d.by).sort().join("|")
+  if (cloud_key !== miningCloudKey) {
+    miningCloudKey = cloud_key
+    miningSim.alpha(0.4).restart()
+  }
+  // place everything immediately so new labels/lines don't flash at the origin
+  mining_cloud_tick()
 }
 
 // size each miner background box to fit its (already positioned) text. Text metrics
@@ -660,6 +957,8 @@ function onBlockClick(c, d) {
   let blockGroup = d3.select(c.target.parentElement.parentElement)
   // only react to clicks on an actual block group
   if (blockGroup.attr("class") == null || !blockGroup.attr("class").startsWith("block")) return
+  // to-be-mined blocks have no real header data to show in the info card
+  if (d.data.data.status == "mining") return
 
   // toggle: if this block already has an open description, close it
   let existing = descLayer.selectAll(".block-description")
@@ -737,7 +1036,7 @@ function onBlockClick(c, d) {
 
   // The full block can only be fetched (via the API) for stale blocks: those
   // that are a tip on some node but not the active chain. The active tip and
-  // ghost "mining" blocks are not served, so we don't offer a link for them.
+  // to-be-mined blocks are not served, so we don't offer a link for them.
   let is_stale = Array.isArray(d.data.data.status)
     && !d.data.data.status.some(s => s.status == "active");
   // The `download` attribute renames the fetched file to `<height>-<hash>.<ext>`.
@@ -894,7 +1193,7 @@ async function draw_nodes() {
 
 orientationSelect.on("input", async function() {
   o = orientations[this.value]
-  await draw()
+  await draw({ reason: "orientation changed", snap: true, clearPoolCloud: true })
 })
 
 // Set the orientation by checking the screen width and height

--- a/www/js/blocktree.js
+++ b/www/js/blocktree.js
@@ -99,12 +99,6 @@ let lastTipPos = { x: 0, y: 0 }
 // See the end of draw().
 let viewAnchor = null
 
-// whether the mining feature is on (?mining, see main.js). blocktree.js is loaded
-// first, so guard against the constant not being there at all.
-function mining_enabled() {
-  return typeof MINING_ENABLED !== "undefined" && MINING_ENABLED
-}
-
 // size a group's background rect to fit the text next to it, with `px`/`py` of padding.
 // Both are only measurable once the text has been laid out, hence the getBBox().
 function fit_rect_to_text(group, px, py) {
@@ -201,6 +195,99 @@ let countdownLayer = g
     .append("g")
     .attr("id", "countdown")
 
+// context from the last draw, so job updates can refresh just the pool cloud (and
+// detect whether a full redraw is actually needed) without re-rendering the blocks.
+let miningDrawCtx = null
+
+// invert the current stratum jobs (state_stratum_jobs, one entry per pool, kept up to
+// date in main.js) into a map of prev_hash -> { parent, pool_names }: the pools mining
+// on each block we recognise. Expired pools are pruned here so the set stays current
+// without a separate timer.
+function current_mining_by_prev(header_infos) {
+  let result = new Map()
+  if (!MINING_ENABLED || state_stratum_jobs.size === 0) {
+    return result
+  }
+  const now = Date.now()
+  // index the real headers by hash so we can resolve a job's parent block
+  let by_hash = new Map()
+  header_infos.forEach(h => by_hash.set(h.hash, h))
+
+  state_stratum_jobs.forEach((job, pool_name) => {
+    // drop pools we haven't heard from in a while
+    if (now - job.last_seen > STRATUM_JOB_TTL_MS) {
+      state_stratum_jobs.delete(pool_name)
+      return
+    }
+    // only show to-be-mined blocks that build on a block we actually know about
+    let parent = by_hash.get(job.prev_hash)
+    if (parent === undefined) return
+    let entry = result.get(job.prev_hash)
+    if (entry === undefined) {
+      entry = { parent, pool_names: [] }
+      result.set(job.prev_hash, entry)
+    }
+    entry.pool_names.push(pool_name)
+  })
+  // stable order, so the labels don't get reshuffled between refreshes
+  result.forEach(entry => entry.pool_names.sort())
+  return result
+}
+
+// build synthetic "being mined" header objects to inject into the tree. One
+// to-be-mined block per prev_hash we recognise, aggregating all pools mining on it.
+function build_mining_headers(header_infos) {
+  let mining_headers = []
+  current_mining_by_prev(header_infos).forEach(({ parent, pool_names }, prev_hash) => {
+    mining_headers.push({
+      id: "mining-" + prev_hash,
+      prev_id: parent.id,
+      height: parent.height + 1,
+      hash: "mining-" + prev_hash,
+      prev_blockhash: prev_hash,
+      // pool names are shown in a force-positioned cloud around the block, so the
+      // block itself carries no miner label
+      miner: "",
+      // not MIN_DIFFICULTY, so it doesn't get the accent-colored stroke
+      difficulty_int: 0,
+      status: "mining",
+      mining_pools: pool_names,
+    })
+  })
+  return mining_headers
+}
+
+// called when new stratum jobs arrive. If the set of being-mined blocks is unchanged
+// (the common case: same tip, just a shifting pool set) only the pool cloud is
+// refreshed, leaving the block DOM — and its running pulse animation — untouched. A
+// full redraw happens only when a to-be-mined block appears or disappears.
+function refresh_mining() {
+  // jobs can arrive before the first fetch has returned; there is nothing to draw yet
+  if (!state_data.header_infos || state_data.header_infos.length == 0) return
+  if (miningDrawCtx === null) {
+    draw({ preserveView: true, reason: "jobs (first draw)" })
+    return
+  }
+  let desired = current_mining_by_prev(state_data.header_infos)
+  let current_keys = miningDrawCtx.toBeMinedByPrev
+  let same = desired.size === current_keys.size &&
+    Array.from(desired.keys()).every(k => current_keys.has(k))
+  if (!same) {
+    log_view("to-be-mined set changed", {
+      was: Array.from(current_keys.keys()).map(k => k.substring(56)),
+      now: Array.from(desired.keys()).map(k => k.substring(56)),
+    })
+    draw({ preserveView: true, reason: "jobs (block set changed)" })
+    return
+  }
+  // same set of blocks: update their pool lists in place and re-lay-out the cloud only
+  desired.forEach(({ pool_names }, prev_hash) => {
+    let node = current_keys.get(prev_hash)
+    if (node) node.data.data.mining_pools = pool_names
+  })
+  draw_mining_pool_clouds(miningDrawCtx.root_node, miningDrawCtx.htoi)
+}
+
 function preprocess_data(data) {
   let header_infos = data.header_infos;
   let node_infos = data.nodes;
@@ -225,13 +312,18 @@ function preprocess_data(data) {
     header_info.is_tip = status != undefined
   })
 
+  // synthetic "being mined" blocks from the stratum jobs feed, injected as children
+  // of the block each pool builds on. max_height (below) stays based on the real
+  // headers only, so these are not treated as the animated newest block.
+  let mining_headers = build_mining_headers(header_infos)
+
   var treeData = d3
     .stratify()
     .id(d => d.id)
     .parentId(function (d) {
       // d3js requires the first prev block hash to be null
       return (d.prev_id == MAX_USIZE ? null : d.prev_id)
-    })(header_infos);
+    })(header_infos.concat(mining_headers));
 
   stripUninteresting(treeData, 4)
 
@@ -259,15 +351,40 @@ function preprocess_data(data) {
 
   let treemap = gen_treemap();
 
+  // Make sure the headers and forks are sorted deterministically. This means, they
+  // don't change on redraws, which is nicer.
+  const sort_blocks = (a, b) =>
+    d3.ascending(a.data.data.height, b.data.data.height) ||
+    d3.ascending(a.data.data.hash, b.data.data.hash)
+
   // assigns the data to a hierarchy using parent-child relationships
-  // and maps the node data to the tree layout. Make sure the headers
-  // and forks are sorted deterministically. This means, they don't
-  // change on redraws, which is nicer.
-  const root_node = treemap(
-    d3.hierarchy(treeData).sort((a, b) =>
-      d3.ascending(a.data.data.height, b.data.data.height) ||
-      d3.ascending(a.data.data.hash, b.data.data.hash))
-  )
+  // and maps the node data to the tree layout.
+  const root_node = treemap(d3.hierarchy(treeData).sort(sort_blocks))
+
+  // Where the real blocks end up across the chain comes from a second run of the same
+  // layout with the feed's synthetic blocks left out. Laying both out together lets the
+  // feed move the real chain around: a to-be-mined block makes the branch it hangs off
+  // one deeper, and d3.tree answers that by pushing the neighbouring branches apart.
+  // Pools switch jobs several times a second, so that showed up as the whole tree
+  // sliding back and forth for no visible reason. Both runs walk the same stripped
+  // tree, so every real block is in both and htoi above stays valid for either.
+  const real_root = treemap(
+    d3.hierarchy(treeData, d => (d.children || []).filter(c => c.data.status != "mining"))
+      .sort(sort_blocks))
+  let real_x = new Map()
+  real_root.descendants().forEach(d => real_x.set(d.data.data.hash, d.x))
+
+  // Pin every real block back to where it sits without the feed. The synthetic ones
+  // aren't in that layout, so they take the shift of the block they hang off - which
+  // keeps them lined up with it and keeps any siblings as far apart as they were.
+  // eachBefore visits parents first, so a node's shift is always known by then.
+  let shift = new Map()
+  root_node.eachBefore(d => {
+    let real = real_x.get(d.data.data.hash)
+    let s = real !== undefined ? real - d.x : shift.get(d.parent)
+    shift.set(d, s)
+    d.x += s
+  })
   const max_height = Math.max(...header_infos.map(d => d.height))
 
   return [root_node, max_height, htoi]
@@ -498,6 +615,13 @@ function draw(opts) {
     draw_mining_pool_clouds(root_node, htoi)
   }
 
+  // remember what we drew so incoming jobs can refresh the cloud in place, without a
+  // full redraw that would restart the to-be-mined blocks' pulse animation
+  let toBeMinedByPrev = new Map()
+  root_node.descendants().filter(d => d.data.data.status == "mining")
+    .forEach(d => toBeMinedByPrev.set(d.data.data.prev_blockhash, d))
+  miningDrawCtx = { root_node, htoi, toBeMinedByPrev }
+
   // size the miner background box to fit its (already positioned) text
   recalc_miner_boxes()
 
@@ -547,7 +671,7 @@ function draw(opts) {
     // block happens to exist right now: pools switch jobs constantly, so anchoring on
     // the block itself dragged the view back and forth by a block slot as it came and
     // went.
-    if (mining_enabled()) {
+    if (MINING_ENABLED) {
       offset_x += o.next_slot.x;
       offset_y += o.next_slot.y;
     }
@@ -597,18 +721,24 @@ function draw(opts) {
 
   log_view("draw", {
     reason: opts.reason || "?",
+    preserveView: !!opts.preserveView,
     orientation: o.name,
     tip: tip_hash && tip_hash.substring(56),
     max_height,
     offset: [offset_x, offset_y],
     viewAnchor, anchor, follow,
+    willMoveCamera: !opts.preserveView && follow,
   })
 
-  if (follow) {
+  // job-triggered redraws (new stratum jobs arriving) pass preserveView so the
+  // viewport isn't yanked back to the tip while the user is panning around.
+  if (!opts.preserveView && follow) {
     viewAnchor = anchor
     zoom.scaleBy(svg, 1);
     let svgSize = d3.select("#drawing-area").node().getBoundingClientRect();
     zoom.translateTo(svg.transition(d3.transition().duration(snap ? 0 : 750)), offset_x, offset_y, o.tip_anchor(svgSize.width, svgSize.height))
+    // only clear this once the view has actually been anchored, so a job-triggered
+    // preserveView redraw can't consume it before the first real draw
     initialDraw = false
   }
 }

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -338,9 +338,10 @@ const STRATUM_SSE_URL = "https://stream.stratum.work/"
 // forget a pool entirely if we haven't heard a job from it within this window, so
 // pools that stop sending (or disappear from the feed) don't linger forever.
 const STRATUM_JOB_TTL_MS = 120000
-// pool_name -> { prev_hash, last_seen }: the one block each pool is currently mining
-// on. Read by build_mining_headers() in blocktree.js on every draw, which groups it
-// the other way round, by the block being mined on.
+// pool_name -> { prev_hash, height, last_seen }: the one block each pool is currently
+// mining on, and the height it is mining at (= that block's height + 1). Read by
+// build_mining_headers() in blocktree.js on every draw, which groups it the other way
+// round, by the block being mined on.
 var state_stratum_jobs = new Map()
 let stratum_redraw_scheduled = false
 
@@ -368,6 +369,7 @@ function record_stratum_job(job) {
   state_stratum_jobs.forEach(other => { if (other.prev_hash == prev_hash) known = true })
   state_stratum_jobs.set(job.pool_name, {
     prev_hash: prev_hash,
+    height: job.height,
     last_seen: Date.now(),
   })
   return !known

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -17,6 +17,11 @@ const soundCheckbox = d3.select("#sound")
 
 const SEARCH_PARAM_NETWORK = "network"
 
+// The mining feature (see the stratum jobs section at the bottom) is opt-in via
+// ?mining. Declared up here because blocktree.js reads it while drawing, which can
+// happen before the bottom of this file has run.
+const MINING_ENABLED = new URLSearchParams(window.location.search).has("mining")
+
 // TODO: should be queried via the API as info
 const PAGE_NAME = "fork-observer"
 
@@ -226,7 +231,7 @@ async function update() {
   await fetch_data()
   check_tip_changed()
   await draw_nodes()
-  await draw()
+  await draw({ reason: "update" })
 }
 
 async function run() {
@@ -308,3 +313,83 @@ changeSSE.addEventListener("cache_changed", (e) => {
 
 
 run()
+
+// ---------------------------------------------------------------------------
+// Stratum jobs feed: show which blocks pools are currently mining on top of.
+// Off by default; enable for testing by adding ?mining to the URL.
+// ---------------------------------------------------------------------------
+
+const STRATUM_SSE_URL = "https://stream.stratum.work/"
+// forget a pool entirely if we haven't heard a job from it within this window, so
+// pools that stop sending (or disappear from the feed) don't linger forever.
+const STRATUM_JOB_TTL_MS = 120000
+// pool_name -> { prev_hash, last_seen }: the one block each pool is currently mining
+// on. Read by build_mining_headers() in blocktree.js on every draw, which groups it
+// the other way round, by the block being mined on.
+var state_stratum_jobs = new Map()
+let stratum_redraw_scheduled = false
+
+// the feed's prev_hash lists the header's 4-byte words in header (little-endian)
+// order; reversing the word order gives the big-endian display hash used
+// everywhere else in the app (header_infos[].hash), so to-be-mined blocks
+// resolve against the real tree.
+function stratum_prevhash_to_display(hex) {
+  let words = []
+  for (let i = 0; i < hex.length; i += 8) words.push(hex.slice(i, i + 8))
+  return words.reverse().join("")
+}
+
+// A pool mines on exactly one block at a time, so a new job replaces whatever we knew
+// about that pool. Keying the state by pool (rather than by the block being mined on)
+// is what makes that replacement automatic: keyed the other way round, a pool that
+// switched to a new block would keep haunting the old one until its TTL ran out, and
+// look like it was mining two blocks at once.
+function record_stratum_job(job) {
+  if (job == null || !job.prev_hash || !job.pool_name) return
+  state_stratum_jobs.set(job.pool_name, {
+    prev_hash: stratum_prevhash_to_display(job.prev_hash),
+    last_seen: Date.now(),
+  })
+}
+
+// jobs arrive several times a second; coalesce them into at most one redraw per
+// window and never recenter the viewport for them.
+function schedule_stratum_redraw() {
+  if (stratum_redraw_scheduled) return
+  stratum_redraw_scheduled = true
+  setTimeout(() => {
+    stratum_redraw_scheduled = false
+    // refresh_mining() only does a full redraw when the set of being-mined blocks
+    // changes; otherwise it just re-lays-out the pool cloud, leaving the
+    // to-be-mined blocks (and their pulse animation) untouched.
+    refresh_mining()
+  }, 1500)
+}
+
+let stratumSource = null
+function connect_stratum() {
+  try {
+    // EventSource reconnects on its own after an error (with the server's
+    // requested retry delay, or a browser default), so no manual backoff here.
+    stratumSource = new EventSource(STRATUM_SSE_URL)
+  } catch (e) {
+    console.error("could not open stratum jobs stream", e)
+    return
+  }
+  stratumSource.addEventListener("message", (e) => {
+    let job
+    try { job = JSON.parse(e.data) } catch (_) { return }
+    record_stratum_job(job)
+    schedule_stratum_redraw()
+  })
+  stratumSource.addEventListener("error", (e) => {
+    console.debug("stratum jobs stream error, browser will retry", e)
+  })
+}
+
+// only connect (and thus show any being-mined blocks) when opted in via ?mining
+if (MINING_ENABLED) {
+  connect_stratum()
+} else {
+  console.debug("mining jobs feed disabled; add ?mining to the URL to enable it")
+}

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -28,6 +28,9 @@ const PAGE_NAME = "fork-observer"
 var state_selected_network_id = 0
 var state_networks = []
 var state_data = {}
+// update_cooling_down: an update ran within the last UPDATE_COOLDOWN_MS.
+// update_scheduled: more events arrived while cooling down, so run one more after.
+var update_cooling_down = false
 var update_scheduled = false
 var state_sound_enabled = false
 // hash of the active chain tip as of the last update, or null if we haven't seen one
@@ -227,7 +230,6 @@ networkSelect.on("input", async function() {
 
 async function update() {
   console.debug("called update()")
-  update_scheduled = false
   await fetch_data()
   check_tip_changed()
   await draw_nodes()
@@ -295,20 +297,33 @@ document.addEventListener("keydown", (e) => {
   }
 })
 
+// When a new block is found every node reports it within a moment of the others, so
+// the events arrive in a burst. Fetch on the first one immediately - waiting only
+// delays showing the block - and then hold off for this long, fetching once more at
+// the end if more events came in, so the later nodes' tips aren't missed.
+const UPDATE_COOLDOWN_MS = 500
+
 changeSSE.addEventListener("cache_changed", (e) => {
   let data = JSON.parse(e.data)
   console.debug("server side event: the data for one of the networks changed: ", data)
-  if(data.network_id == state_selected_network_id) {
-    console.debug("server side event: the data for current network changed: ", data)
-    if (!update_scheduled) {
-      // wait for 500ms before fetching data
-      // this avoid fetching data in rapid succession when a new block is found
-      setTimeout(update, 500);
-      update_scheduled = true;
-    } else {
-      console.debug("server side event: update for the current network already sheduled: ", data)
-    }
+  if(data.network_id != state_selected_network_id) return
+  console.debug("server side event: the data for current network changed: ", data)
+
+  if (update_cooling_down) {
+    // an update ran just now; remember to run one more once the window is over
+    update_scheduled = true
+    console.debug("server side event: update for the current network already sheduled: ", data)
+    return
   }
+  update_cooling_down = true
+  update()
+  setTimeout(() => {
+    update_cooling_down = false
+    if (update_scheduled) {
+      update_scheduled = false
+      update()
+    }
+  }, UPDATE_COOLDOWN_MS)
 })
 
 
@@ -344,26 +359,41 @@ function stratum_prevhash_to_display(hex) {
 // is what makes that replacement automatic: keyed the other way round, a pool that
 // switched to a new block would keep haunting the old one until its TTL ran out, and
 // look like it was mining two blocks at once.
+// Returns true when the job moves this pool onto a block no other pool was mining on,
+// i.e. when it changes which blocks are drawn rather than just who is on them.
 function record_stratum_job(job) {
-  if (job == null || !job.prev_hash || !job.pool_name) return
+  if (job == null || !job.prev_hash || !job.pool_name) return false
+  let prev_hash = stratum_prevhash_to_display(job.prev_hash)
+  let known = false
+  state_stratum_jobs.forEach(other => { if (other.prev_hash == prev_hash) known = true })
   state_stratum_jobs.set(job.pool_name, {
-    prev_hash: stratum_prevhash_to_display(job.prev_hash),
+    prev_hash: prev_hash,
     last_seen: Date.now(),
   })
+  return !known
 }
 
-// jobs arrive several times a second; coalesce them into at most one redraw per
-// window and never recenter the viewport for them.
-function schedule_stratum_redraw() {
+// how long to coalesce jobs that only shuffle pools between blocks we already draw
+const STRATUM_REDRAW_COALESCE_MS = 300
+
+// Jobs arrive several times a second, so they are coalesced into at most one redraw
+// per window (and never recenter the viewport). The exception is a job that puts a
+// pool on a block we aren't drawing yet - the first pool to switch after a new block
+// is found - which redraws straight away, since that is the moment the display is
+// out of date and worth updating. refresh_mining() only does a full redraw when the
+// set of being-mined blocks changes; otherwise it just re-lays-out the pool cloud,
+// leaving the to-be-mined blocks (and their pulse animation) untouched.
+function schedule_stratum_redraw(immediate) {
+  if (immediate) {
+    refresh_mining()
+    return
+  }
   if (stratum_redraw_scheduled) return
   stratum_redraw_scheduled = true
   setTimeout(() => {
     stratum_redraw_scheduled = false
-    // refresh_mining() only does a full redraw when the set of being-mined blocks
-    // changes; otherwise it just re-lays-out the pool cloud, leaving the
-    // to-be-mined blocks (and their pulse animation) untouched.
     refresh_mining()
-  }, 1500)
+  }, STRATUM_REDRAW_COALESCE_MS)
 }
 
 let stratumSource = null
@@ -379,8 +409,8 @@ function connect_stratum() {
   stratumSource.addEventListener("message", (e) => {
     let job
     try { job = JSON.parse(e.data) } catch (_) { return }
-    record_stratum_job(job)
-    schedule_stratum_redraw()
+    let new_block = record_stratum_job(job)
+    schedule_stratum_redraw(new_block)
   })
   stratumSource.addEventListener("error", (e) => {
     console.debug("stratum jobs stream error, browser will retry", e)


### PR DESCRIPTION
This subscribes to a stratum jobs feed (currently from stream.stratum.work) and renders to-be-mined blocks. This allows us to see which pool is mining on which block.

This is experimental and needs `?mining` as an argument to the URL to be enabled.