### PR TITLE
fix: draw a to-be-mined block that forks the tip as a fork

### DIFF
--- a/www/js/blocktree.js
+++ b/www/js/blocktree.js
@@ -466,15 +466,23 @@ function preprocess_data(data) {
   // Pools switch jobs several times a second, so that showed up as the whole tree
   // sliding back and forth for no visible reason. Both runs walk the same stripped
   // tree, so every real block is in both and htoi above stays valid for either.
+  //
+  // Only the feed blocks ahead of our tip are left out that way. One at or below it
+  // competes with a block we already have, so it is a fork and is laid out with the
+  // real blocks - which separates it from its sibling like any other fork, instead of
+  // leaving it half a slot away and drawn over it. That moves the chain, but so would
+  // the confirmed block it stands in for.
+  const beyond_our_tip = d => from_stratum_feed(d.data) && d.data.height > max_height
   const real_root = treemap(
-    d3.hierarchy(treeData, d => (d.children || []).filter(c => !from_stratum_feed(c.data)))
+    d3.hierarchy(treeData, d => (d.children || []).filter(c => !beyond_our_tip(c)))
       .sort(sort_blocks))
   let real_x = new Map()
   real_root.descendants().forEach(d => real_x.set(d.data.data.hash, d.x))
 
   // Pin every real block back to where it sits without the feed. The synthetic ones
-  // aren't in that layout, so they take the shift of the block they hang off - which
-  // keeps them lined up with it and keeps any siblings as far apart as they were.
+  // ahead of the tip aren't in that layout, so they take the shift of the block they
+  // hang off - which keeps them lined up with it and keeps any siblings as far apart
+  // as they were.
   // eachBefore visits parents first, so a node's shift is always known by then.
   let shift = new Map()
   root_node.eachBefore(d => {


### PR DESCRIPTION
The blocks from the stratum jobs feed are kept out of the layout pass that decides where the real blocks go, so that pools switching jobs several times a second can't slide the whole chain around. Every real block is pinned back to the position that pass gives it; the feed's blocks aren't in it and simply follow the block they hang off.

That falls apart when a pool is mining on the block below our tip. The to-be-mined block then competes with the tip, and d3 splits the two apart by half a slot each. The tip is pinned back onto the chain afterwards, but nothing pins the to-be-mined block, so it keeps its half slot - half the separation a fork gets, less than a block is tall. It was drawn over the tip's miner label and tip status boxes.

A feed block at or below our tip's height competes with a block we already have, which makes it a fork, so it now takes part in that layout pass too and is separated from its sibling exactly like a confirmed block would be. The ones ahead of the tip - the ordinary being-mined block and the just-found stand-in - stay out of it, so nothing about the common case changes.

A fork moves the chain aside, and this one does too, including for the few seconds after a block is found while the last pools are still mining on the block below it. That is what a real fork block arriving there would do as well.