### PR TITLE
fix: resolve cargo clippy warnings and add CI lint job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,3 +23,13 @@ jobs:
       run: cargo test --verbose --all-features
     - name: Run cargo fmt
       run: cargo fmt --all -- --check
+
+  lint:
+
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run cargo clippy
+      run: cargo clippy --verbose --all-targets --all-features

--- a/src/api.rs
+++ b/src/api.rs
@@ -15,7 +15,7 @@ use tokio_stream::wrappers::BroadcastStream;
 use warp::{sse::Event, Filter};
 
 pub fn build_routes(
-    network_infos: &Vec<NetworkJson>,
+    network_infos: &[NetworkJson],
     config: &Config,
     caches: &Caches,
     cache_changed_tx_warp: Sender<u32>,
@@ -78,28 +78,28 @@ pub fn build_routes(
     let forks_rss = warp::get()
         .and(warp::path!("rss" / u32 / "forks.xml"))
         .and(with_caches(caches.clone()))
-        .and(with_networks(network_infos.clone()))
+        .and(with_networks(network_infos.to_vec()))
         .and(rss::with_rss_base_url(config.rss_base_url.clone()))
         .and_then(rss::forks_response);
 
     let invalid_blocks_rss = warp::get()
         .and(warp::path!("rss" / u32 / "invalid.xml"))
         .and(with_caches(caches.clone()))
-        .and(with_networks(network_infos.clone()))
+        .and(with_networks(network_infos.to_vec()))
         .and(rss::with_rss_base_url(config.rss_base_url.clone()))
         .and_then(rss::invalid_blocks_response);
 
     let lagging_nodes_rss = warp::get()
         .and(warp::path!("rss" / u32 / "lagging.xml"))
         .and(with_caches(caches.clone()))
-        .and(with_networks(network_infos.clone()))
+        .and(with_networks(network_infos.to_vec()))
         .and(rss::with_rss_base_url(config.rss_base_url.clone()))
         .and_then(rss::lagging_nodes_response);
 
     let unreachable_nodes_rss = warp::get()
         .and(warp::path!("rss" / u32 / "unreachable.xml"))
         .and(with_caches(caches.clone()))
-        .and(with_networks(network_infos.clone()))
+        .and(with_networks(network_infos.to_vec()))
         .and(rss::with_rss_base_url(config.rss_base_url.clone()))
         .and_then(rss::unreachable_nodes_response);
 
@@ -376,7 +376,7 @@ pub async fn slug_redirect_response(
     slug: String,
     slugs: Vec<String>,
 ) -> Result<impl warp::Reply, warp::Rejection> {
-    if slugs.iter().any(|s| *s == slug) {
+    if slugs.contains(&slug) {
         Ok(warp::http::Response::builder()
             .status(warp::http::StatusCode::FOUND)
             .header("location", format!("./?network={}", slug))

--- a/src/backend/bitcoin_core.rs
+++ b/src/backend/bitcoin_core.rs
@@ -95,7 +95,7 @@ impl Node for BitcoinCoreNode {
 
     async fn block_header_hash(&self, hash: &BlockHash) -> Result<Header, FetchError> {
         let rpc = self.rpc_client()?;
-        let hash_clone = hash.clone();
+        let hash_clone = *hash;
         task::spawn_blocking(move || -> Result<Header, FetchError> {
             Ok(rpc
                 .get_block_header(&hash_clone)?
@@ -115,7 +115,7 @@ impl Node for BitcoinCoreNode {
 
     async fn coinbase(&self, hash: &BlockHash, _height: u64) -> Result<Transaction, FetchError> {
         let rpc = self.rpc_client()?;
-        let hash_clone = hash.clone();
+        let hash_clone = *hash;
         match task::spawn_blocking(move || rpc.get_block(hash_clone)).await {
             Ok(result) => match result {
                 Ok(result) => Ok(result
@@ -206,8 +206,7 @@ impl Node for BitcoinCoreNode {
         let start_hash = self.block_hash(start_height).await?;
         debug!(
             "loading active-chain headers starting from {} ({})",
-            start_height,
-            start_hash.to_string()
+            start_height, start_hash
         );
 
         let url = format!(
@@ -248,7 +247,7 @@ impl Node for BitcoinCoreNode {
             "loaded {} active-chain headers starting from {} ({})",
             headers.len(),
             start_height,
-            start_hash.to_string()
+            start_hash
         );
 
         Ok(headers)

--- a/src/backend/electrum.rs
+++ b/src/backend/electrum.rs
@@ -75,7 +75,7 @@ impl Node for Electrum {
     }
 
     fn rpc_url(&self) -> String {
-        return "not used".to_string();
+        "not used".to_string()
     }
 
     async fn version(&self) -> Result<String, FetchError> {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -87,7 +87,7 @@ pub trait Node: Sync {
 
     async fn new_headers(
         &self,
-        tips: &Vec<ChainTip>,
+        tips: &[ChainTip],
         tree: &Tree,
         min_fork_height: u64,
     ) -> Result<(Vec<HeaderInfo>, Vec<BlockHash>), FetchError> {
@@ -117,7 +117,7 @@ pub trait Node: Sync {
 
     async fn new_active_headers(
         &self,
-        tips: &Vec<ChainTip>,
+        tips: &[ChainTip],
         tree: &Tree,
         min_fork_height: u64,
     ) -> Result<Vec<HeaderInfo>, FetchError> {
@@ -125,8 +125,7 @@ pub trait Node: Sync {
 
         let active_tip = match tips
             .iter()
-            .filter(|tip| tip.status == ChainTipStatus::Active)
-            .last()
+            .rfind(|tip| tip.status == ChainTipStatus::Active)
         {
             Some(active_tip) => active_tip,
             None => {
@@ -189,15 +188,12 @@ pub trait Node: Sync {
                     }
                     // since we are fetching "active" (i.e. in the main chain) headers,
                     // we can fetch by block height here too.
-                    let header: Header;
-                    match self.capabilities().header_fetch_type {
-                        HeaderFetchType::Hash => {
-                            header = self.block_header_hash(&header_hash).await?;
-                        }
+                    let header: Header = match self.capabilities().header_fetch_type {
+                        HeaderFetchType::Hash => self.block_header_hash(&header_hash).await?,
                         HeaderFetchType::Height => {
-                            header = self.block_header_height(query_height as u64).await?;
+                            self.block_header_height(query_height as u64).await?
                         }
-                    }
+                    };
                     new_headers.push(HeaderInfo {
                         height: query_height as u64,
                         header,
@@ -217,7 +213,7 @@ pub trait Node: Sync {
 
     async fn new_nonactive_headers(
         &self,
-        tips: &Vec<ChainTip>,
+        tips: &[ChainTip],
         tree: &Tree,
         min_fork_height: u64,
     ) -> Result<Vec<HeaderInfo>, FetchError> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -561,7 +561,7 @@ fn parse_toml_node(toml_node: &TomlNode) -> Result<BoxedSyncSendNode, ConfigErro
             let url = format!(
                 "{}:{}",
                 toml_node.rpc_host.clone(),
-                toml_node.rpc_port.clone().unwrap_or(50002).to_string()
+                toml_node.rpc_port.unwrap_or(50002)
             );
             Arc::new(Electrum::new(node_info, url))
         }
@@ -580,15 +580,17 @@ mod tests {
 
         const FILENAME_EXAMPLE_CONFIG: &str = "config.toml.example";
         env::set_var(ENVVAR_CONFIG_FILE, FILENAME_EXAMPLE_CONFIG);
-        let cfg = load_config().expect(&format!(
-            "We should be able to load the {} file.",
-            FILENAME_EXAMPLE_CONFIG
-        ));
+        let cfg = load_config().unwrap_or_else(|_| {
+            panic!(
+                "We should be able to load the {} file.",
+                FILENAME_EXAMPLE_CONFIG
+            )
+        });
 
         assert_eq!(cfg.address.to_string(), "127.0.0.1:2323");
         assert_eq!(cfg.networks.len(), 2);
         assert_eq!(cfg.query_interval, std::time::Duration::from_secs(15));
-        assert_eq!(cfg.networks[0].pool_identification.enable, true);
+        assert!(cfg.networks[0].pool_identification.enable);
     }
 
     #[test]
@@ -614,11 +616,9 @@ mod tests {
         )
         .expect("node without use_waitfornewblock should parse");
         assert_eq!(node.use_waitfornewblock, None);
-        assert_eq!(
-            node.use_waitfornewblock
-                .unwrap_or(DEFAULT_USE_WAITFORNEWBLOCK),
-            true
-        );
+        assert!(node
+            .use_waitfornewblock
+            .unwrap_or(DEFAULT_USE_WAITFORNEWBLOCK));
 
         // Honors an explicit `false`.
         let node: TomlNode = toml::from_str(

--- a/src/db.rs
+++ b/src/db.rs
@@ -64,7 +64,7 @@ pub async fn write_to_db(
             "INSERT OR IGNORE INTO headers
                    (height, network, hash, header, miner)
                    values (?1, ?2, ?3, ?4, ?5)",
-            &[
+            [
                 &info.height.to_string(),
                 &network.to_string(),
                 &info.header.block_hash().to_string(),

--- a/src/headertree.rs
+++ b/src/headertree.rs
@@ -37,21 +37,20 @@ pub async fn sorted_interesting_heights(
     // Combine the heights with multiple blocks with the tip_heights.
     let mut interesting_heights_set: BTreeSet<u64> = heights_with_multiple_blocks
         .iter()
-        .map(|i| *i)
+        .copied()
         .chain(tip_heights)
         .collect();
 
     // We are also interested in the block with the max height. We should
     // already have that in `tip_heights`, but include it here just to be
     // sure.
-    let max_height: u64 = height_occurences
-        .iter()
-        .map(|(k, _)| *k)
+    let max_height: u64 = *height_occurences
+        .keys()
         .max()
         .expect("we should have at least one height here as we have blocks");
     interesting_heights_set.insert(max_height);
 
-    let mut interesting_heights: Vec<u64> = interesting_heights_set.iter().map(|h| *h).collect();
+    let mut interesting_heights: Vec<u64> = interesting_heights_set.iter().copied().collect();
     interesting_heights.sort();
 
     // As, for example, testnet has a lot of forks we'd return many headers
@@ -59,7 +58,7 @@ pub async fn sorted_interesting_heights(
     // max_interesting_heights.
     interesting_heights = interesting_heights_set
         .iter()
-        .map(|h| *h)
+        .copied()
         .rev() // reversing: ascending -> descending
         .take(max_interesting_heights) // taking the 'last' max_interesting_heights
         .rev() // reversing: descending -> ascending
@@ -157,17 +156,14 @@ pub async fn strip_tree(
     let mut headers: Vec<HeaderInfoJson> = Vec::new();
     for idx in striped_tree.node_indices() {
         let prev_nodes = striped_tree.neighbors_directed(idx, petgraph::Direction::Incoming);
-        let prev_node_index: usize;
-        match prev_nodes.clone().count() {
-            0 => prev_node_index = usize::MAX, // indicates the start in JavaScript
-            1 => {
-                prev_node_index = prev_nodes
-                    .last()
-                    .expect("we should have exactly one previous node")
-                    .index()
-            }
+        let prev_node_index: usize = match prev_nodes.clone().count() {
+            0 => usize::MAX, // indicates the start in JavaScript
+            1 => prev_nodes
+                .last()
+                .expect("we should have exactly one previous node")
+                .index(),
             _ => panic!("got multiple previous nodes. this should not happen."),
-        }
+        };
         headers.push(HeaderInfoJson::new(
             striped_tree[idx],
             idx.index(),
@@ -256,7 +252,7 @@ pub async fn stale_blocks(tree: &Tree, how_many: usize) -> Vec<StaleBlockJson> {
         .collect();
 
     // Return the most recent (highest) stale blocks first, capped at `how_many`.
-    stale.sort_by(|a, b| b.height.cmp(&a.height));
+    stale.sort_by_key(|b| std::cmp::Reverse(b.height));
     stale.truncate(how_many);
     stale
 }

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -84,12 +84,12 @@ pub fn btcd_chaintips(
     }
 
     if let Some(response) = jsonrpc_response.result {
-        return Ok(response);
+        Ok(response)
     } else {
-        return Err(JsonRPCError::JsonRpc(format!(
+        Err(JsonRPCError::JsonRpc(format!(
             "JSON RPC response for request '{}' was empty.",
             METHOD
-        )));
+        )))
     }
 }
 
@@ -126,7 +126,7 @@ pub fn btcd_blockheader(
     let header_bytes = hex::decode(header_hex)?;
 
     let header: Header = corepc_client::bitcoin::consensus::deserialize(&header_bytes)?;
-    return Ok(header);
+    Ok(header)
 }
 
 pub fn btcd_block(

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,27 +121,26 @@ async fn startup() -> Result<(config::Config, Db, Caches, Option<Activity>), Mai
 }
 
 async fn populate_cache(network: &config::Network, tree: &Tree, caches: &Caches) {
-    let forks = headertree::recent_forks(&tree, MAX_FORKS_IN_CACHE).await;
+    let forks = headertree::recent_forks(tree, MAX_FORKS_IN_CACHE).await;
     let hij = headertree::strip_tree(
-        &tree,
+        tree,
         network.max_interesting_heights,
         BTreeSet::new(),
         network.countdown.as_ref().map(|c| c.height),
     )
     .await;
-    let stale_blocks = headertree::stale_blocks(&tree, MAX_STALE_BLOCKS).await;
+    let stale_blocks = headertree::stale_blocks(tree, MAX_STALE_BLOCKS).await;
     {
         let mut locked_caches = caches.lock().await;
         let node_data: NodeData = network
             .nodes
             .iter()
-            .cloned()
             .map(|n| {
                 (
                     n.info().id,
                     NodeDataJson::new(
                         n.info(),
-                        &vec![],                     // no chain tips knows yet
+                        &[],                         // no chain tips knows yet
                         VERSION_UNKNOWN.to_string(), // is updated later, when we know it
                         0,                           // timestamp of last block update
                         true, // assume the node is reachable, if it isn't we set it to false after the first getchaintips RPC call anyway
@@ -210,7 +209,7 @@ async fn main() -> Result<(), MainError> {
         }
     }
 
-    for network in config.networks.iter().cloned() {
+    for network in config.networks.iter() {
         let network = network.clone();
         let (pool_id_tx, mut pool_id_rx) = unbounded_channel::<BlockHash>();
 
@@ -243,7 +242,8 @@ async fn main() -> Result<(), MainError> {
         let lagging_state: Arc<Mutex<BTreeMap<u32, bool>>> = Arc::new(Mutex::new(BTreeMap::new()));
         let network_logs_activity = activity.is_some() && !network.activity_log_node_ids.is_empty();
 
-        for node in network.nodes.iter().cloned() {
+        for node in network.nodes.iter() {
+            let node = node.clone();
             let network = network.clone();
             let query_interval = config.query_interval;
             // Spread the initial query times apart to even out network/CPU load
@@ -509,7 +509,7 @@ async fn main() -> Result<(), MainError> {
                 .0
                 .raw_nodes()
                 .iter()
-                .filter(|node| node.weight.miner == "" || node.weight.miner == MINER_UNKNOWN)
+                .filter(|node| node.weight.miner.is_empty() || node.weight.miner == MINER_UNKNOWN)
                 .filter(|node| {
                     let h = node.weight.height;
                     interesting_heights.contains(&h)
@@ -561,7 +561,7 @@ async fn main() -> Result<(), MainError> {
                         match tree_locked.1.get(hash) {
                             Some(idx) => *idx,
                             None => {
-                                error!("Block hash {} not (yet) present in tree for network: {}. Skipping identification...", hash.to_string(), network_clone.name);
+                                error!("Block hash {} not (yet) present in tree for network: {}. Skipping identification...", hash, network_clone.name);
                                 continue;
                             }
                         }
@@ -573,13 +573,12 @@ async fn main() -> Result<(), MainError> {
                     };
 
                     // skip miner identification if we previously identified a miner
-                    if !(header_info.miner == MINER_UNKNOWN.to_string() || header_info.miner == "")
-                    {
+                    if !(header_info.miner == MINER_UNKNOWN || header_info.miner.is_empty()) {
                         continue;
                     }
 
                     let mut miner = MINER_UNKNOWN.to_string();
-                    for node in network_clone.nodes.iter().cloned() {
+                    for node in network_clone.nodes.iter() {
                         match node
                             .coinbase(&header_info.header.block_hash(), header_info.height)
                             .await
@@ -596,13 +595,13 @@ async fn main() -> Result<(), MainError> {
                             Err(e) => {
                                 warn!(
                                     "Could not get coinbase for block {} from node {}: {}",
-                                    header_info.header.block_hash().to_string(),
+                                    header_info.header.block_hash(),
                                     node.info().name,
                                     e
                                 );
                             }
                         }
-                        if miner != MINER_UNKNOWN.to_string() {
+                        if miner != MINER_UNKNOWN {
                             info!(
                                 "Updated miner for block {} from node {}: {}",
                                 header_info.height,
@@ -630,7 +629,7 @@ async fn main() -> Result<(), MainError> {
                         warn!(
                             "Could not update miner to {} for block {}: {}",
                             header_info.miner.clone(),
-                            &header_info.header.block_hash(),
+                            header_info.header.block_hash(),
                             e
                         );
                     }
@@ -894,10 +893,7 @@ async fn update_cache(
             let stale_hashes: HashSet<String> =
                 stale_blocks.iter().map(|b| b.hash.clone()).collect();
             locked_cache.entry(network_id).and_modify(|e| {
-                e.header_infos_json = new_header_infos_map
-                    .iter()
-                    .map(|(_, header)| header.clone())
-                    .collect();
+                e.header_infos_json = new_header_infos_map.values().cloned().collect();
                 e.forks = forks;
                 e.stale_blocks = stale_blocks;
                 // Drop cached blocks that are no longer in the stale list, so the
@@ -1004,7 +1000,7 @@ async fn load_node_version(node: BoxedSyncSendNode, network: &str) -> String {
         network,
         VERSION_UNKNOWN
     );
-    return VERSION_UNKNOWN.to_string();
+    VERSION_UNKNOWN.to_string()
 }
 
 async fn insert_new_headers_into_tree(tree: &Tree, new_headers: &[HeaderInfo]) -> bool {
@@ -1075,7 +1071,7 @@ mod tests {
             let mut node_data: NodeData = BTreeMap::new();
             node_data.insert(
                 node.id,
-                NodeDataJson::new(node.clone(), &vec![], "".to_string(), 0, true),
+                NodeDataJson::new(node.clone(), &[], "".to_string(), 0, true),
             );
             locked_caches.insert(
                 network_id,
@@ -1089,10 +1085,7 @@ mod tests {
                 },
             );
         }
-        assert_eq!(
-            get_test_node_reachable(&caches, network_id, node.id).await,
-            true
-        );
+        assert!(get_test_node_reachable(&caches, network_id, node.id).await);
 
         update_cache(
             &caches,
@@ -1104,10 +1097,7 @@ mod tests {
             &dummy_sender,
         )
         .await;
-        assert_eq!(
-            get_test_node_reachable(&caches, network_id, node.id).await,
-            false
-        );
+        assert!(!get_test_node_reachable(&caches, network_id, node.id).await);
 
         update_cache(
             &caches,
@@ -1119,10 +1109,7 @@ mod tests {
             &dummy_sender,
         )
         .await;
-        assert_eq!(
-            get_test_node_reachable(&caches, network_id, node.id).await,
-            true
-        );
+        assert!(get_test_node_reachable(&caches, network_id, node.id).await);
     }
 
     #[tokio::test]
@@ -1159,8 +1146,8 @@ mod tests {
             CacheUpdate::RemoteNodes {
                 removed_node_ids: vec![],
                 nodes: vec![
-                    NodeDataJson::new(node_info(1000, "A"), &vec![], "".to_string(), 0, true),
-                    NodeDataJson::new(node_info(1001, "B"), &vec![], "".to_string(), 0, true),
+                    NodeDataJson::new(node_info(1000, "A"), &[], "".to_string(), 0, true),
+                    NodeDataJson::new(node_info(1001, "B"), &[], "".to_string(), 0, true),
                 ],
             },
             &dummy_sender,
@@ -1182,7 +1169,7 @@ mod tests {
                 removed_node_ids: vec![1001],
                 nodes: vec![NodeDataJson::new(
                     node_info(1000, "A renamed"),
-                    &vec![],
+                    &[],
                     "".to_string(),
                     0,
                     false,
@@ -1197,7 +1184,7 @@ mod tests {
             assert_eq!(node_data.len(), 1);
             let node = node_data.get(&1000).unwrap();
             assert_eq!(node.name, "A renamed");
-            assert_eq!(node.reachable, false);
+            assert!(!node.reachable);
             assert!(!node_data.contains_key(&1001));
         }
     }

--- a/src/remote_forkobserver.rs
+++ b/src/remote_forkobserver.rs
@@ -575,7 +575,7 @@ mod tests {
                 description: "".to_string(),
                 implementation: "test".to_string(),
             },
-            &vec![],
+            &[],
             "".to_string(),
             0,
             true,
@@ -732,7 +732,7 @@ mod tests {
         let network = test_network(1);
         // We already know `root` (a local node fetched it), which is what lets us
         // place `child`. Headers we can't anchor aren't imported.
-        let tree: Tree = Arc::new(Mutex::new(tree_of(&[root.clone()])));
+        let tree: Tree = Arc::new(Mutex::new(tree_of(std::slice::from_ref(&root))));
         let db = memory_db().await;
         let caches = empty_caches(network.id).await;
         let (cache_changed_tx, mut cache_changed_rx) = broadcast::channel(16);

--- a/src/rss.rs
+++ b/src/rss.rs
@@ -100,7 +100,7 @@ impl From<Fork> for Item {
             description: format!(
                 "There are {} blocks building on-top of block {}.",
                 fork.children.len(),
-                fork.common.header.block_hash().to_string()
+                fork.common.header.block_hash()
             ),
             guid: fork.common.header.block_hash().to_string(),
         }
@@ -110,7 +110,7 @@ impl From<Fork> for Item {
 impl From<(&TipInfoJson, &Vec<NodeDataJson>)> for Item {
     fn from(invalid_block: (&TipInfoJson, &Vec<NodeDataJson>)) -> Self {
         let mut nodes = invalid_block.1.clone();
-        nodes.sort_by(|a, b| a.id.cmp(&b.id));
+        nodes.sort_by_key(|a| a.id);
 
         Item {
             title: format!("Invalid block at height {}", invalid_block.0.height,),
@@ -223,14 +223,13 @@ pub async fn lagging_nodes_response(
             if cache.node_data.len() > 1 {
                 let nodes_with_active_height: Vec<(&NodeDataJson, u64)> = cache
                     .node_data
-                    .iter()
-                    .map(|(_, node)| {
+                    .values()
+                    .map(|node| {
                         (
                             node,
                             node.tips
                                 .iter()
-                                .filter(|tip| tip.status == "active".to_string())
-                                .last()
+                                .rfind(|tip| tip.status == "active")
                                 .unwrap_or(&TipInfoJson {
                                     height: 0,
                                     status: "active".to_string(),
@@ -309,7 +308,7 @@ pub async fn invalid_blocks_response(
 
             let mut invalid_blocks: Vec<(&TipInfoJson, &Vec<NodeDataJson>)> =
                 invalid_blocks_to_node_id.iter().collect();
-            invalid_blocks.sort_by(|a, b| b.0.height.cmp(&a.0.height));
+            invalid_blocks.sort_by_key(|b| std::cmp::Reverse(b.0.height));
             let feed = Feed {
                 channel: Channel {
                     title: format!("Invalid Blocks - {}", network_name),
@@ -330,9 +329,9 @@ pub async fn invalid_blocks_response(
                 },
             };
 
-            return Ok(Response::builder()
+            Ok(Response::builder()
                 .header("content-type", "application/rss+xml")
-                .body(feed.to_string()));
+                .body(feed.to_string()))
         }
         None => Ok(Ok(response_unknown_network(network_infos))),
     }
@@ -362,7 +361,7 @@ pub async fn unreachable_nodes_response(
                 .node_data
                 .values()
                 .filter(|node| !node.reachable)
-                .map(|node| Item::unreachable_node_item(node))
+                .map(Item::unreachable_node_item)
                 .collect();
             let feed = Feed {
                 channel: Channel {
@@ -381,9 +380,9 @@ pub async fn unreachable_nodes_response(
                 },
             };
 
-            return Ok(Response::builder()
+            Ok(Response::builder()
                 .header("content-type", "application/rss+xml")
-                .body(feed.to_string()));
+                .body(feed.to_string()))
         }
         None => Ok(Ok(response_unknown_network(network_infos))),
     }
@@ -392,7 +391,7 @@ pub async fn unreachable_nodes_response(
 pub fn response_unknown_network(network_infos: Vec<NetworkJson>) -> Response<String> {
     let avaliable_networks = network_infos
         .iter()
-        .map(|net| format!("{} ({})", net.id.to_string(), net.name))
+        .map(|net| format!("{} ({})", net.id, net.name))
         .collect::<Vec<String>>();
 
     Response::builder()

--- a/src/types.rs
+++ b/src/types.rs
@@ -211,7 +211,7 @@ pub struct NodeDataJson {
 impl NodeDataJson {
     pub fn new(
         info: NodeInfo,
-        tips: &Vec<ChainTip>,
+        tips: &[ChainTip],
         version: String,
         last_changed_timestamp: u64,
         reachable: bool,


### PR DESCRIPTION
Fix all warnings from 'cargo clippy --all-targets --all-features' (ptr_arg, needless_return, to_string_in_format_args, clone_on_copy, bool_assert_comparison, iter_kv_map, unnecessary_sort_by, and redundant clones/closures). Add a lint job to the Rust CI workflow that runs clippy so these don't regress.

closes #155 