### PR TITLE
add: BLAKE2b (v2) block header support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,13 +64,13 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -238,6 +238,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -416,6 +425,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -543,6 +553,7 @@ dependencies = [
  "async-trait",
  "base64 0.23.0",
  "bitcoin-pool-identification",
+ "blake2",
  "corepc-client 0.16.0",
  "corepc-node",
  "electrum-client",
@@ -852,11 +863,11 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
- "once_cell",
+ "cfg-if",
  "wasm-bindgen",
 ]
 
@@ -978,9 +989,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "percent-encoding"
@@ -1636,15 +1647,15 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1655,9 +1666,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1665,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1678,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ futures-util = "0.3"
 petgraph = { version = "0.8.2", features = ["serde-1"] }
 
 base64 = "0.23.0"
+blake2 = "0.10.6"
 
 async-trait = "0.1.89"
 bitcoin-pool-identification = "0.3.7"

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -840,7 +840,7 @@ mod tests {
     fn hi(height: u64, header: Header) -> HeaderInfo {
         HeaderInfo {
             height,
-            header,
+            header: header.into(),
             miner: String::new(),
         }
     }

--- a/src/backend/bitcoin_core.rs
+++ b/src/backend/bitcoin_core.rs
@@ -1,8 +1,8 @@
 use super::{Capabilities, HeaderFetchType, Node, NodeInfo};
+use crate::blake2b::ParsedHeader;
 use crate::error::FetchError;
 use crate::types::ChainTip;
 use async_trait::async_trait;
-use corepc_client::bitcoin::blockdata::block::Header;
 use corepc_client::bitcoin::{BlockHash, Transaction};
 use corepc_client::client_sync::v31::Client;
 use corepc_client::client_sync::Auth;
@@ -93,20 +93,36 @@ impl Node for BitcoinCoreNode {
         .await?
     }
 
-    async fn block_header_hash(&self, hash: &BlockHash) -> Result<Header, FetchError> {
+    async fn block_header_hash(&self, hash: &BlockHash) -> Result<ParsedHeader, FetchError> {
         let rpc = self.rpc_client()?;
         let hash_clone = hash.clone();
-        task::spawn_blocking(move || -> Result<Header, FetchError> {
-            Ok(rpc
-                .get_block_header(&hash_clone)?
-                .into_model()
-                .map_err(|e| FetchError::DataError(e.to_string()))?
-                .0)
+        task::spawn_blocking(move || -> Result<ParsedHeader, FetchError> {
+            // Ask for the raw header rather than the typed model: the model is a
+            // fixed 80-byte SHA256d header and cannot represent a BLAKE2b (v2)
+            // one, which would silently yield the wrong block hash.
+            let header_hex: String = rpc.call(
+                "getblockheader",
+                &[hash_clone.to_string().into(), false.into()],
+            )?;
+            let header_bytes = hex::decode(&header_hex).map_err(|e| {
+                FetchError::DataError(format!(
+                    "could not hex decode block header '{}': {}",
+                    header_hex, e
+                ))
+            })?;
+            let (header, v2, _) = crate::blake2b::parse_header(&header_bytes).map_err(|e| {
+                FetchError::DataError(format!(
+                    "could not deserialize block header '{}': {}",
+                    header_hex, e
+                ))
+            })?;
+
+            Ok(ParsedHeader { header, v2 })
         })
         .await?
     }
 
-    async fn block_header_height(&self, _: u64) -> Result<Header, FetchError> {
+    async fn block_header_height(&self, _: u64) -> Result<ParsedHeader, FetchError> {
         assert_eq!(self.capabilities().header_fetch_type, HeaderFetchType::Hash);
         Err(FetchError::DataError(
             "fetch by block height not implemented".to_string(),
@@ -200,7 +216,7 @@ impl Node for BitcoinCoreNode {
         &self,
         start_height: u64,
         count: u64,
-    ) -> Result<Vec<Header>, FetchError> {
+    ) -> Result<Vec<ParsedHeader>, FetchError> {
         // The REST headers endpoint is addressed by hash; resolve the start
         // height with a (cheap) `getblockhash` RPC first.
         let start_hash = self.block_hash(start_height).await?;
@@ -228,13 +244,9 @@ impl Node for BitcoinCoreNode {
             )));
         }
 
-        let header_results: Result<Vec<Header>, corepc_client::bitcoin::consensus::encode::Error> =
-            res.as_bytes()
-                .chunks(80)
-                .map(corepc_client::bitcoin::consensus::deserialize::<Header>)
-                .collect();
-
-        let headers = match header_results {
+        // Headers are not a fixed stride: a BLAKE2b (v2) header is 164 bytes
+        // where a SHA256d one is 80, so the stream has to be walked.
+        let headers = match crate::blake2b::parse_headers(res.as_bytes()) {
             Ok(headers) => headers,
             Err(e) => {
                 return Err(FetchError::BitcoinCoreREST(format!(

--- a/src/backend/block_dn.rs
+++ b/src/backend/block_dn.rs
@@ -1,4 +1,5 @@
 use super::{Capabilities, HeaderFetchType, Node, NodeInfo};
+use crate::blake2b::ParsedHeader;
 use crate::error::FetchError;
 use crate::types::{ChainTip, ChainTipStatus};
 use async_trait::async_trait;
@@ -146,7 +147,7 @@ impl BlockDn {
         &self,
         height: u64,
         count: u64,
-    ) -> Result<Vec<Header>, FetchError> {
+    ) -> Result<Vec<ParsedHeader>, FetchError> {
         let mut bytes: Vec<u8> = Vec::new();
         for (file_start, byte_start, byte_end) in blockdn_header_requests(height, count) {
             let expected_len = (byte_end - byte_start + 1) as usize;
@@ -169,6 +170,7 @@ impl BlockDn {
                 .collect();
 
         header_results
+            .map(|headers| headers.into_iter().map(ParsedHeader::from).collect())
             .map_err(|e| FetchError::BlockDnREST(format!("could not deserialize header: {}", e)))
     }
 }
@@ -198,7 +200,7 @@ impl Node for BlockDn {
             .ok_or_else(|| FetchError::BlockDnREST("/status did not include a version".to_string()))
     }
 
-    async fn block_header_hash(&self, _hash: &BlockHash) -> Result<Header, FetchError> {
+    async fn block_header_hash(&self, _hash: &BlockHash) -> Result<ParsedHeader, FetchError> {
         assert_eq!(
             self.capabilities().header_fetch_type,
             HeaderFetchType::Height
@@ -208,7 +210,7 @@ impl Node for BlockDn {
         ))
     }
 
-    async fn block_header_height(&self, height: u64) -> Result<Header, FetchError> {
+    async fn block_header_height(&self, height: u64) -> Result<ParsedHeader, FetchError> {
         self.fetch_headers_range(height, 1)
             .await?
             .into_iter()
@@ -282,7 +284,7 @@ impl Node for BlockDn {
         &self,
         start_height: u64,
         count: u64,
-    ) -> Result<Vec<Header>, FetchError> {
+    ) -> Result<Vec<ParsedHeader>, FetchError> {
         self.fetch_headers_range(start_height, count).await
     }
 }

--- a/src/backend/btcd.rs
+++ b/src/backend/btcd.rs
@@ -1,8 +1,8 @@
 use super::{Capabilities, HeaderFetchType, Node, NodeInfo};
+use crate::blake2b::ParsedHeader;
 use crate::error::{FetchError, JsonRPCError};
 use crate::types::ChainTip;
 use async_trait::async_trait;
-use corepc_client::bitcoin::blockdata::block::Header;
 use corepc_client::bitcoin::{BlockHash, Transaction};
 
 #[derive(Hash, Clone)]
@@ -46,7 +46,7 @@ impl Node for BtcdNode {
         Err(FetchError::BtcdRPC(JsonRPCError::NotImplemented))
     }
 
-    async fn block_header_hash(&self, hash: &BlockHash) -> Result<Header, FetchError> {
+    async fn block_header_hash(&self, hash: &BlockHash) -> Result<ParsedHeader, FetchError> {
         let url = format!("{}/", self.rpc_url);
         match crate::jsonrpc::btcd_blockheader(
             url,
@@ -54,12 +54,12 @@ impl Node for BtcdNode {
             self.rpc_password.clone(),
             hash.to_string(),
         ) {
-            Ok(header) => Ok(header),
+            Ok(header) => Ok(header.into()),
             Err(error) => Err(FetchError::BtcdRPC(error)),
         }
     }
 
-    async fn block_header_height(&self, _: u64) -> Result<Header, FetchError> {
+    async fn block_header_height(&self, _: u64) -> Result<ParsedHeader, FetchError> {
         assert_eq!(self.capabilities().header_fetch_type, HeaderFetchType::Hash);
         Err(FetchError::DataError(
             "fetch by block height not implemented".to_string(),
@@ -70,7 +70,7 @@ impl Node for BtcdNode {
         &self,
         _start_height: u64,
         _count: u64,
-    ) -> Result<Vec<Header>, FetchError> {
+    ) -> Result<Vec<ParsedHeader>, FetchError> {
         assert!(self.capabilities().batch_header_fetch);
         Err(FetchError::DataError(
             "batch header fetch not implemented".to_string(),

--- a/src/backend/electrum.rs
+++ b/src/backend/electrum.rs
@@ -1,8 +1,8 @@
 use super::{Capabilities, HeaderFetchType, Node, NodeInfo};
+use crate::blake2b::ParsedHeader;
 use crate::error::FetchError;
 use crate::types::{ChainTip, ChainTipStatus};
 use async_trait::async_trait;
-use corepc_client::bitcoin::blockdata::block::Header;
 use corepc_client::bitcoin::{BlockHash, Transaction};
 use electrum_client::{
     Client as ElectrumClient, ConfigBuilder as ElectrumClientConfigBuilder, ElectrumApi,
@@ -84,17 +84,17 @@ impl Node for Electrum {
         Ok(response.server_version)
     }
 
-    async fn block_header_hash(&self, _hash: &BlockHash) -> Result<Header, FetchError> {
+    async fn block_header_hash(&self, _hash: &BlockHash) -> Result<ParsedHeader, FetchError> {
         // hm, no lookup via BlockHash possible I think?
         return Err(FetchError::DataError(
             "block_header not implemented".to_string(),
         ));
     }
 
-    async fn block_header_height(&self, height: u64) -> Result<Header, FetchError> {
+    async fn block_header_height(&self, height: u64) -> Result<ParsedHeader, FetchError> {
         let client = self.get_client();
         let header = client.block_header(height as usize)?;
-        Ok(header)
+        Ok(header.into())
     }
 
     async fn block_hash(&self, height: u64) -> Result<BlockHash, FetchError> {
@@ -178,10 +178,13 @@ impl Node for Electrum {
         &self,
         start_height: u64,
         count: u64,
-    ) -> Result<Vec<Header>, FetchError> {
+    ) -> Result<Vec<ParsedHeader>, FetchError> {
         let client = self.get_client();
         Ok(client
             .block_headers(start_height as usize, count as usize)?
-            .headers)
+            .headers
+            .into_iter()
+            .map(ParsedHeader::from)
+            .collect())
     }
 }

--- a/src/backend/esplora.rs
+++ b/src/backend/esplora.rs
@@ -1,8 +1,8 @@
 use super::{Capabilities, HeaderFetchType, Node, NodeInfo};
+use crate::blake2b::ParsedHeader;
 use crate::error::{EsploraRESTError, FetchError};
 use crate::types::{ChainTip, ChainTipStatus};
 use async_trait::async_trait;
-use corepc_client::bitcoin::blockdata::block::Header;
 use corepc_client::bitcoin::hex::FromHex;
 use corepc_client::bitcoin::{BlockHash, Transaction};
 use std::str::FromStr;
@@ -41,7 +41,7 @@ impl Node for Esplora {
         Err(FetchError::EsploraREST(EsploraRESTError::NotImplemented))
     }
 
-    async fn block_header_hash(&self, hash: &BlockHash) -> Result<Header, FetchError> {
+    async fn block_header_hash(&self, hash: &BlockHash) -> Result<ParsedHeader, FetchError> {
         let url = format!("{}/block/{}/header", self.api_url, hash);
 
         let res = minreq::get(url.clone())
@@ -53,15 +53,13 @@ impl Node for Esplora {
             200 => {
                 let header_str = res.as_str()?;
                 match Vec::from_hex(header_str) {
-                    Ok(header_bytes) => {
-                        match corepc_client::bitcoin::consensus::deserialize(&header_bytes) {
-                            Ok(header) => Ok(header),
-                            Err(e) => Err(FetchError::DataError(format!(
-                                "Can't deserialize block header '{}': {}",
-                                header_str, e
-                            ))),
-                        }
-                    }
+                    Ok(header_bytes) => match crate::blake2b::parse_header(&header_bytes) {
+                        Ok((header, v2, _)) => Ok(ParsedHeader { header, v2 }),
+                        Err(e) => Err(FetchError::DataError(format!(
+                            "Can't deserialize block header '{}': {}",
+                            header_str, e
+                        ))),
+                    },
                     Err(e) => Err(FetchError::DataError(format!(
                         "Can't hex decode block header '{}': {}",
                         header_str, e
@@ -80,7 +78,7 @@ impl Node for Esplora {
         }
     }
 
-    async fn block_header_height(&self, _: u64) -> Result<Header, FetchError> {
+    async fn block_header_height(&self, _: u64) -> Result<ParsedHeader, FetchError> {
         assert_eq!(self.capabilities().header_fetch_type, HeaderFetchType::Hash);
         Err(FetchError::DataError(
             "fetch by block height not implemented".to_string(),
@@ -195,7 +193,7 @@ impl Node for Esplora {
         &self,
         _start_height: u64,
         _count: u64,
-    ) -> Result<Vec<Header>, FetchError> {
+    ) -> Result<Vec<ParsedHeader>, FetchError> {
         assert!(self.capabilities().batch_header_fetch);
         Err(FetchError::DataError(
             "batch header fetch not implemented".to_string(),

--- a/src/backend/mempool_space.rs
+++ b/src/backend/mempool_space.rs
@@ -1,9 +1,9 @@
 use super::esplora::Esplora;
 use super::{Capabilities, HeaderFetchType, Node, NodeInfo};
+use crate::blake2b::ParsedHeader;
 use crate::error::{EsploraRESTError, FetchError};
 use crate::types::ChainTip;
 use async_trait::async_trait;
-use corepc_client::bitcoin::blockdata::block::Header;
 use corepc_client::bitcoin::hex::FromHex;
 use corepc_client::bitcoin::{BlockHash, Transaction};
 use log::debug;
@@ -33,20 +33,20 @@ struct MempoolSpaceBackendInfo {
 fn header_from_mempool_space_block(
     hash: &BlockHash,
     block: &MempoolSpaceBlock,
-) -> Result<Header, FetchError> {
+) -> Result<ParsedHeader, FetchError> {
     let header_bytes = Vec::from_hex(&block.extras.header).map_err(|e| {
         FetchError::DataError(format!(
             "Can't hex decode block header '{}' for block {}: {}",
             block.extras.header, hash, e
         ))
     })?;
-    let header: Header =
-        corepc_client::bitcoin::consensus::deserialize(&header_bytes).map_err(|e| {
-            FetchError::DataError(format!(
-                "Can't deserialize block header '{}' for block {}: {}",
-                block.extras.header, hash, e
-            ))
-        })?;
+    let (inner, v2, _) = crate::blake2b::parse_header(&header_bytes).map_err(|e| {
+        FetchError::DataError(format!(
+            "Can't deserialize block header '{}' for block {}: {}",
+            block.extras.header, hash, e
+        ))
+    })?;
+    let header = ParsedHeader { header: inner, v2 };
 
     if header.block_hash() != *hash {
         return Err(FetchError::DataError(format!(
@@ -129,12 +129,12 @@ impl Node for MempoolSpace {
         Ok(info.version)
     }
 
-    async fn block_header_hash(&self, hash: &BlockHash) -> Result<Header, FetchError> {
+    async fn block_header_hash(&self, hash: &BlockHash) -> Result<ParsedHeader, FetchError> {
         let block: MempoolSpaceBlock = self.get_json(&format!("/block/{}", hash)).await?;
         header_from_mempool_space_block(hash, &block)
     }
 
-    async fn block_header_height(&self, _: u64) -> Result<Header, FetchError> {
+    async fn block_header_height(&self, _: u64) -> Result<ParsedHeader, FetchError> {
         assert_eq!(self.capabilities().header_fetch_type, HeaderFetchType::Hash);
         Err(FetchError::DataError(
             "fetch by block height not implemented".to_string(),
@@ -157,7 +157,7 @@ impl Node for MempoolSpace {
         &self,
         _start_height: u64,
         _count: u64,
-    ) -> Result<Vec<Header>, FetchError> {
+    ) -> Result<Vec<ParsedHeader>, FetchError> {
         assert!(self.capabilities().batch_header_fetch);
         Err(FetchError::DataError(
             "batch header fetch not implemented".to_string(),

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -16,10 +16,10 @@ pub use electrum::Electrum;
 pub use esplora::Esplora;
 pub use mempool_space::MempoolSpace;
 
+use crate::blake2b::ParsedHeader;
 use crate::error::FetchError;
 use crate::types::{ChainTip, ChainTipStatus, HeaderInfo, Tree};
 use async_trait::async_trait;
-use corepc_client::bitcoin::blockdata::block::Header;
 use corepc_client::bitcoin::{BlockHash, Transaction};
 use log::debug;
 use std::cmp::max;
@@ -56,8 +56,8 @@ pub trait Node: Sync {
     fn capabilities(&self) -> Capabilities;
     fn rpc_url(&self) -> String;
     async fn version(&self) -> Result<String, FetchError>;
-    async fn block_header_hash(&self, hash: &BlockHash) -> Result<Header, FetchError>;
-    async fn block_header_height(&self, height: u64) -> Result<Header, FetchError>;
+    async fn block_header_hash(&self, hash: &BlockHash) -> Result<ParsedHeader, FetchError>;
+    async fn block_header_height(&self, height: u64) -> Result<ParsedHeader, FetchError>;
     async fn block_hash(&self, height: u64) -> Result<BlockHash, FetchError>;
     async fn tips(&self) -> Result<Vec<ChainTip>, FetchError>;
     async fn coinbase(&self, hash: &BlockHash, height: u64) -> Result<Transaction, FetchError>;
@@ -71,7 +71,7 @@ pub trait Node: Sync {
         &self,
         start_height: u64,
         count: u64,
-    ) -> Result<Vec<Header>, FetchError>;
+    ) -> Result<Vec<ParsedHeader>, FetchError>;
 
     /// Blocks until the node's tip likely changed, or until `timeout` elapses,
     /// whichever comes first. Returning is only a hint to re-fetch tips; callers
@@ -163,7 +163,7 @@ pub trait Node: Sync {
                             .contains_key(&height_header_pair.0.block_hash())
                         {
                             new_headers.push(HeaderInfo {
-                                header: *height_header_pair.0,
+                                header: height_header_pair.0.clone(),
                                 height: height_header_pair.1 as u64,
                                 miner: DEFAULT_EMPTY_MINER.to_string(),
                             });
@@ -189,7 +189,7 @@ pub trait Node: Sync {
                     }
                     // since we are fetching "active" (i.e. in the main chain) headers,
                     // we can fetch by block height here too.
-                    let header: Header;
+                    let header: ParsedHeader;
                     match self.capabilities().header_fetch_type {
                         HeaderFetchType::Hash => {
                             header = self.block_header_hash(&header_hash).await?;
@@ -261,12 +261,12 @@ pub trait Node: Sync {
                     }
                     Err(e) => return Err(e),
                 };
+                next_header = header.prev_blockhash;
                 new_headers.push(HeaderInfo {
                     height,
                     header,
                     miner: DEFAULT_EMPTY_MINER.to_string(),
                 });
-                next_header = header.prev_blockhash;
             }
         }
         Ok(new_headers)

--- a/src/blake2b.rs
+++ b/src/blake2b.rs
@@ -1,0 +1,499 @@
+//! BLAKE2b header support for the BIP-110 chain.
+//!
+//! The BLAKE2b hardfork activated at mainnet height 961,640. Blocks from that
+//! height carry a "header v2": the classic 80-byte header with the top version
+//! bit set, followed by 84 bytes of extra fields, and a block hash built from
+//! BLAKE2b rather than SHA256d.
+
+use std::convert::TryInto;
+
+use blake2::digest::consts::U32;
+use blake2::{Blake2b, Digest};
+use corepc_client::bitcoin::blockdata::block::{Header, Version};
+use corepc_client::bitcoin::hashes::{sha256, Hash};
+use corepc_client::bitcoin::{BlockHash, CompactTarget, TxMerkleNode};
+
+/// Top bit of the on-wire version field, flagging a v2 header.
+pub const VERSION_HEADER_V2_FLAG: u32 = 0x8000_0000;
+/// Set when `nTime` is carried as `time_on_wire + time_offset`.
+const FLAG_USE_TIME_OFFSET: u8 = 4;
+
+pub const HEADER_V1_SIZE: usize = 80;
+pub const HEADER_V2_EXTRA_SIZE: usize = 84;
+pub const HEADER_V2_SIZE: usize = HEADER_V1_SIZE + HEADER_V2_EXTRA_SIZE;
+
+/// The extra fields a v2 header carries after the classic 80 bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeaderV2 {
+    /// The version exactly as it appeared on the wire, v2 flag included. The
+    /// block hash commits to this, so it cannot be recovered from `Header`.
+    pub complete_version: u32,
+    /// `nTime` before the offset is folded in; also what the hash commits to.
+    pub time_on_wire: u32,
+    pub nonce2: u32,
+    pub nonce3: u32,
+    pub extranonce: [u8; 16],
+    pub time_offset: u32,
+    pub txcount: u16,
+    pub flags: u8,
+    pub xor_key_mask_clear_bits: u8,
+    pub xor_key: [u8; 16],
+    pub height: i32,
+    pub mm_rhs: [u8; 32],
+}
+
+#[derive(Debug)]
+pub enum ParseError {
+    Truncated { need: usize, got: usize },
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            ParseError::Truncated { need, got } => {
+                write!(f, "truncated header: need {} bytes, got {}", need, got)
+            }
+        }
+    }
+}
+
+struct Reader<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn take(&mut self, n: usize) -> Result<&'a [u8], ParseError> {
+        let end = self.pos + n;
+        if end > self.bytes.len() {
+            return Err(ParseError::Truncated {
+                need: end,
+                got: self.bytes.len(),
+            });
+        }
+        let out = &self.bytes[self.pos..end];
+        self.pos = end;
+        Ok(out)
+    }
+
+    fn u32(&mut self) -> Result<u32, ParseError> {
+        Ok(u32::from_le_bytes(
+            self.take(4)?.try_into().expect("4 bytes"),
+        ))
+    }
+
+    fn u16(&mut self) -> Result<u16, ParseError> {
+        Ok(u16::from_le_bytes(
+            self.take(2)?.try_into().expect("2 bytes"),
+        ))
+    }
+
+    fn u8(&mut self) -> Result<u8, ParseError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn array<const N: usize>(&mut self) -> Result<[u8; N], ParseError> {
+        Ok(self.take(N)?.try_into().expect("N bytes"))
+    }
+}
+
+/// Parses one header, returning it and how many bytes it consumed. A v1 header
+/// consumes 80 bytes and a v2 header 164, which is why the REST header stream
+/// cannot be split on a fixed stride.
+pub fn parse_header(bytes: &[u8]) -> Result<(Header, Option<HeaderV2>, usize), ParseError> {
+    let mut r = Reader { bytes, pos: 0 };
+
+    let complete_version = r.u32()?;
+    let prev_blockhash = BlockHash::from_byte_array(r.array::<32>()?);
+    let merkle_root = TxMerkleNode::from_byte_array(r.array::<32>()?);
+    let time_on_wire = r.u32()?;
+    let bits = CompactTarget::from_consensus(r.u32()?);
+    let nonce = r.u32()?;
+
+    let is_v2 = complete_version & VERSION_HEADER_V2_FLAG != 0;
+    // Consensus strips the flag before treating the field as a version, so the
+    // deployment bits line up with pre-fork blocks.
+    let version = Version::from_consensus((complete_version & !VERSION_HEADER_V2_FLAG) as i32);
+
+    if !is_v2 {
+        let header = Header {
+            version,
+            prev_blockhash,
+            merkle_root,
+            time: time_on_wire,
+            bits,
+            nonce,
+        };
+        return Ok((header, None, r.pos));
+    }
+
+    let v2 = HeaderV2 {
+        complete_version,
+        time_on_wire,
+        nonce2: r.u32()?,
+        nonce3: r.u32()?,
+        extranonce: r.array::<16>()?,
+        time_offset: r.u32()?,
+        txcount: r.u16()?,
+        flags: r.u8()?,
+        xor_key_mask_clear_bits: r.u8()?,
+        xor_key: r.array::<16>()?,
+        height: r.u32()? as i32,
+        mm_rhs: r.array::<32>()?,
+    };
+
+    let time = if v2.flags & FLAG_USE_TIME_OFFSET != 0 {
+        time_on_wire.wrapping_add(v2.time_offset)
+    } else {
+        time_on_wire
+    };
+
+    let header = Header {
+        version,
+        prev_blockhash,
+        merkle_root,
+        time,
+        bits,
+        nonce,
+    };
+
+    Ok((header, Some(v2), r.pos))
+}
+
+/// Parses a concatenated header stream, as returned by `/rest/headers/*.bin`.
+pub fn parse_headers(bytes: &[u8]) -> Result<Vec<ParsedHeader>, ParseError> {
+    let mut out = Vec::new();
+    let mut offset = 0;
+
+    while offset < bytes.len() {
+        let (header, v2, used) = parse_header(&bytes[offset..])?;
+        out.push(ParsedHeader { header, v2 });
+        offset += used;
+    }
+
+    Ok(out)
+}
+
+fn tagged(tag: &str) -> sha256::HashEngine {
+    use corepc_client::bitcoin::hashes::HashEngine;
+
+    let tag_hash = sha256::Hash::hash(tag.as_bytes());
+    let mut engine = sha256::Hash::engine();
+    engine.input(tag_hash.as_byte_array());
+    engine.input(tag_hash.as_byte_array());
+    engine
+}
+
+fn blake2b256(data: &[u8]) -> [u8; 32] {
+    let mut hasher = Blake2b::<U32>::new();
+    hasher.update(data);
+    hasher.finalize().into()
+}
+
+/// The block hash of a v2 header.
+///
+/// Mirrors `CBlockHeader::GetHash()` in Bitcoin Knots: two tagged SHA256
+/// commitments, a BLAKE2b pass over the Sv1 coinbase prefix, a second BLAKE2b
+/// over the fields the mining hardware sees, then an XOR mask.
+pub fn block_hash_v2(header: &Header, v2: &HeaderV2) -> BlockHash {
+    use corepc_client::bitcoin::hashes::HashEngine;
+
+    const ZEROS: [u8; 16] = [0u8; 16];
+
+    let mut e = tagged("Bitcoin block hash PoW XOR key");
+    e.input(&v2.xor_key);
+    let xor_key_hash = sha256::Hash::from_engine(e);
+
+    let mut xor_key_mask = [0u8; 32];
+    if v2.xor_key != ZEROS {
+        let mut e = tagged("Bitcoin block hash PoW XOR mask");
+        e.input(&v2.xor_key);
+        xor_key_mask = sha256::Hash::from_engine(e).to_byte_array();
+
+        let clear_bytes = (v2.xor_key_mask_clear_bits / 8) as usize;
+        for byte in xor_key_mask.iter_mut().take(clear_bytes) {
+            *byte = 0;
+        }
+        xor_key_mask[clear_bytes] &= 0xffu8 >> (v2.xor_key_mask_clear_bits % 8);
+    }
+
+    // Knots hashes the prevhash in "sane" (big-endian) order.
+    let mut prev_sane = header.prev_blockhash.to_byte_array();
+    prev_sane.reverse();
+
+    let mut e = tagged("Bitcoin prevblock header, hashed");
+    e.input(&prev_sane);
+    let mut prev_hidden = sha256::Hash::from_engine(e).to_byte_array();
+
+    let mut h1 = tagged("Bitcoin block header 1");
+    h1.input(&v2.complete_version.to_le_bytes());
+    h1.input(&prev_sane);
+    h1.input(&v2.height.to_le_bytes());
+    h1.input(header.merkle_root.as_byte_array());
+    h1.input(&v2.time_on_wire.to_le_bytes());
+    h1.input(&[0u8]); // reserved for extended 40-bit time
+    h1.input(&header.bits.to_consensus().to_le_bytes());
+    h1.input(&(v2.txcount as u32).to_le_bytes());
+    h1.input(&[v2.flags]);
+    h1.input(&[v2.xor_key_mask_clear_bits]);
+    h1.input(xor_key_hash.as_byte_array());
+    let h1_hash = sha256::Hash::from_engine(h1);
+
+    let mut h2 = tagged("Merge-mining hook");
+    h2.input(h1_hash.as_byte_array());
+    h2.input(&ZEROS);
+    h2.input(&ZEROS);
+    h2.input(&v2.mm_rhs);
+    let h2_hash = sha256::Hash::from_engine(h2).to_byte_array();
+
+    let mut ss = Vec::with_capacity(52);
+    ss.extend_from_slice(&0u32.to_le_bytes());
+    ss.extend_from_slice(&h2_hash);
+    ss.extend_from_slice(&v2.extranonce);
+    let mut hash = blake2b256(&ss);
+
+    let nonce = header.nonce.to_le_bytes();
+    let nonce2 = v2.nonce2.to_le_bytes();
+    let nonce3 = v2.nonce3.to_le_bytes();
+    let time_offset = v2.time_offset.to_le_bytes();
+
+    let mut ss = Vec::new();
+    match v2.flags & 3 {
+        3 | 2 => {
+            if v2.flags & 3 == 3 {
+                ss.extend_from_slice(&ZEROS);
+                ss.extend_from_slice(&ZEROS);
+            }
+            ss.extend_from_slice(&ZEROS);
+            ss.extend_from_slice(&ZEROS);
+            ss.extend_from_slice(&ZEROS);
+            ss.extend_from_slice(&h2_hash);
+            ss.extend_from_slice(&nonce);
+            ss.extend_from_slice(&nonce2);
+            ss.extend_from_slice(&time_offset);
+            ss.extend_from_slice(&nonce3);
+            ss.extend_from_slice(&hash);
+        }
+        0 => {
+            for byte in prev_hidden.iter_mut().take(6) {
+                *byte = 0;
+            }
+            ss.extend_from_slice(&prev_hidden);
+            ss.extend_from_slice(&nonce);
+            ss.extend_from_slice(&nonce2);
+            ss.extend_from_slice(&time_offset);
+            ss.extend_from_slice(&nonce3);
+            ss.extend_from_slice(&hash);
+        }
+        _ => {
+            ss.extend_from_slice(&nonce);
+            ss.extend_from_slice(&nonce2);
+            ss.extend_from_slice(&nonce3);
+            ss.extend_from_slice(&time_offset);
+            ss.extend_from_slice(&hash);
+            ss.extend_from_slice(&h2_hash);
+        }
+    }
+    hash = blake2b256(&ss);
+
+    let mut out = [0u8; 32];
+    for i in 0..32 {
+        out[i] = hash[i] ^ xor_key_mask[i];
+    }
+    out.reverse();
+
+    BlockHash::from_byte_array(out)
+}
+
+/// Serializes a header back to its exact wire form: 80 bytes for SHA256d, 164
+/// for BLAKE2b. `consensus::serialize` cannot be used for v2, since it drops
+/// the flag and the extra fields, which the block hash commits to.
+pub fn serialize(header: &Header, v2: Option<&HeaderV2>) -> Vec<u8> {
+    let (complete_version, time_on_wire) = match v2 {
+        Some(v2) => (v2.complete_version, v2.time_on_wire),
+        None => (header.version.to_consensus() as u32, header.time),
+    };
+
+    let mut out = Vec::with_capacity(match v2 {
+        Some(_) => HEADER_V2_SIZE,
+        None => HEADER_V1_SIZE,
+    });
+    out.extend_from_slice(&complete_version.to_le_bytes());
+    out.extend_from_slice(&header.prev_blockhash.to_byte_array());
+    out.extend_from_slice(header.merkle_root.as_byte_array());
+    out.extend_from_slice(&time_on_wire.to_le_bytes());
+    out.extend_from_slice(&header.bits.to_consensus().to_le_bytes());
+    out.extend_from_slice(&header.nonce.to_le_bytes());
+
+    if let Some(v2) = v2 {
+        out.extend_from_slice(&v2.nonce2.to_le_bytes());
+        out.extend_from_slice(&v2.nonce3.to_le_bytes());
+        out.extend_from_slice(&v2.extranonce);
+        out.extend_from_slice(&v2.time_offset.to_le_bytes());
+        out.extend_from_slice(&v2.txcount.to_le_bytes());
+        out.push(v2.flags);
+        out.push(v2.xor_key_mask_clear_bits);
+        out.extend_from_slice(&v2.xor_key);
+        out.extend_from_slice(&v2.height.to_le_bytes());
+        out.extend_from_slice(&v2.mm_rhs);
+    }
+
+    out
+}
+
+/// A header together with its v2 fields, if it has any. Backends that only
+/// ever see SHA256d blocks can build one with `Header::into()`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedHeader {
+    pub header: Header,
+    pub v2: Option<HeaderV2>,
+}
+
+impl ParsedHeader {
+    /// The block hash under whichever proof-of-work this block was mined with.
+    /// This shadows `Header::block_hash()`, which is SHA256d-only and therefore
+    /// wrong for v2 headers, so existing call sites stay correct as they are.
+    pub fn block_hash(&self) -> BlockHash {
+        block_hash(&self.header, self.v2.as_ref())
+    }
+}
+
+/// Lets a `ParsedHeader` be read exactly like the `Header` it wraps.
+impl std::ops::Deref for ParsedHeader {
+    type Target = Header;
+
+    fn deref(&self) -> &Header {
+        &self.header
+    }
+}
+
+impl From<Header> for ParsedHeader {
+    fn from(header: Header) -> Self {
+        ParsedHeader { header, v2: None }
+    }
+}
+
+/// The block hash of a header, whichever proof-of-work it was mined under.
+pub fn block_hash(header: &Header, v2: Option<&HeaderV2>) -> BlockHash {
+    match v2 {
+        Some(v2) => block_hash_v2(header, v2),
+        None => header.block_hash(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Real mainnet headers: the last SHA256d block and three BLAKE2b blocks.
+    const HEADERS: [(&str, &str); 4] = [
+    // mainnet block 961,639
+    ("10000a205fca17a6566978303e989d163e1aa9dc6715eef5542e0000000000000000000080fe52c98f1c1f8484213dff5a88315f7c334d0705f7d79579b289781868c0dff5c1916a3d350217510c87ed", "00000000000000000001bbc439e13f749dca850d32c7a2834165338713027e65"),
+    // mainnet block 961,640
+    ("000000a0657e02138733654183a2c7320d85ca9d743fe139c4bb01000000000000000000c137a8515a0f6b3aaf6049cc7611787c022ad523d51094be0a0363d0dc0bc7684dca936a4f8d001a5671798c84daeb494dca936a00000000b1ccf00d0300000000000000000000001e0300000000000000000000000000000000000068ac0e000000000000000000000000000000000000000000000000000000000000000000", "0000000000000050c1e5f69672f459293be14f46e5a494e7a8c8541396f18eeb"),
+    // mainnet block 962,000
+    ("000000a0f71a4ef4bee6b127cc3702bd08b4f58c8f8e8c1ceff76d6b62000000000000006eb7af7c0e41375c874f4875d8c6a7c569db2c46815bc3904e94a866234f3983d3d7946a4f8d001aa9fd379f4da6971bd3d7946a00000000b10cf00d030000000000000000000000c403000000000000000000000000000000000000d0ad0e000000000000000000000000000000000000000000000000000000000000000000", "000000000000003a65dc8991928c4d2865a424ac7ab5de981cc959828784ea0e"),
+    // mainnet block 962,400
+    ("000000a0ea0603d0c8fc0f3a5faf1ff68d762a9d891da3eeefd708b66e00000000000000f79a91deb8b15796b494fe57f2da2856eba100822b3564a3cd1b9386fb0acb5ed6a5956a4f8d001af4b630187635ee04d6a5956a00000000b14cf00d030000000000000000000000480300000000000000000000000000000000000060af0e000000000000000000000000000000000000000000000000000000000000000000", "000000000000005d5e0941a3c747bfd24e8f1abe945f04d2243a3cb6128b76f5"),
+    ];
+
+    fn parse(hex_str: &str) -> (Header, Option<HeaderV2>, usize) {
+        parse_header(&hex::decode(hex_str).expect("valid hex")).expect("parses")
+    }
+
+    #[test]
+    fn parses_v1_and_v2_sizes() {
+        let (_, v2, used) = parse(HEADERS[0].0);
+        assert!(v2.is_none(), "961,639 predates the fork");
+        assert_eq!(used, HEADER_V1_SIZE);
+
+        for (hex_str, _) in HEADERS.iter().skip(1) {
+            let (_, v2, used) = parse(hex_str);
+            assert!(v2.is_some(), "post-fork blocks carry a v2 header");
+            assert_eq!(used, HEADER_V2_SIZE);
+        }
+    }
+
+    #[test]
+    fn computes_block_hashes() {
+        for (hex_str, expected) in HEADERS.iter() {
+            let (header, v2, _) = parse(hex_str);
+            assert_eq!(block_hash(&header, v2.as_ref()).to_string(), *expected);
+        }
+    }
+
+    #[test]
+    fn strips_the_v2_flag_from_the_version() {
+        let (header, v2, _) = parse(HEADERS[1].0);
+        let v2 = v2.expect("v2 header");
+
+        assert_ne!(v2.complete_version & VERSION_HEADER_V2_FLAG, 0);
+        // Consensus sees 0x20000000, so BIP-9 bit reads still work.
+        assert_eq!(header.version.to_consensus(), 0x2000_0000);
+    }
+
+    #[test]
+    fn parses_a_mixed_header_stream() {
+        let mut stream = Vec::new();
+        for (hex_str, _) in HEADERS.iter() {
+            stream.extend_from_slice(&hex::decode(hex_str).expect("valid hex"));
+        }
+
+        let headers = parse_headers(&stream).expect("stream parses");
+        assert_eq!(headers.len(), HEADERS.len());
+
+        for (parsed, (_, expected)) in headers.iter().zip(HEADERS.iter()) {
+            assert_eq!(parsed.block_hash().to_string(), *expected);
+        }
+    }
+
+    /// Real testnet4 headers straight off a Bitcoin Knots v29.4.1 node, spanning
+    /// its own BLAKE2b activation at height 150,308.
+    const TESTNET4_HEADERS: [(&str, &str); 4] = [
+        // testnet4 block 150,307
+        ("00e0572cb60133b39f77761d271c389f3de1cd9079db9fd46df7eb6b8d8a230000000000b78b78c0f2dacc8b911d5c3b439de9a03148729bb0a482205f2a5493f05817f94378936affff001d2200f068", "000000000017ec2251d81c8d2ca401c713e98e85196c7f660a4088a7ca57b1cc"),
+        // testnet4 block 150,308
+        ("000000a0ccb157caa788400a667f6c19858ee913c701a42c8d1cd85122ec17000000000043d2e57990429ae581621ce01aa5fbf5e4c2723996be18660a4930b91e96d6c871b4946affff001dce0ac801d123881f71b4946a00000000b10cf00d0100000000000000000000008e00000000000000000000000000000000000000244b02000000000000000000000000000000000000000000000000000000000000000000", "000000000000b9d1b7e1bb0e77215ee92c6ef7ec8f4473e23908380649e779b6"),
+        // testnet4 block 150,309
+        ("000000a0b679e74906380839e273448fecf76e2ce95e21770ebbe1b7d1b9000000000000b89a9a63a3e422bc9e7a866a2979dcdb4f4a63df0958fa798d3645fbfb1cac1487b9946affff001d73541009b64dc60f87b9946a00000000b10cf00d0100000000000000000000002200000000000000000000000000000000000000254b02000000000000000000000000000000000000000000000000000000000000000000", "00000000000096ebd9ecd086095f024d8eb4d1cdb9d8b124dc0e610a4f24f858"),
+        // testnet4 block 150,310
+        ("000000a058f8244f0a610edc24b1d8b9cdd1b48e4d025f0986d0ecd9eb96000000000000ff7848f442580dfb1d962ded6ec4bb676e3f4e434b1d5d6d0bb74a9d444f4c3d47c3946affff001d01540859a6125c2b47c3946a00000000b10cf00d0100000000000000000000000400000000000000000000000000000000000000264b02000000000000000000000000000000000000000000000000000000000000000000", "0000000000013427d1a6ec47d2fab6ebdc2e06a02b4bdd6e5d92d2ad2e897111"),
+    ];
+
+    #[test]
+    fn matches_a_live_knots_node_across_activation() {
+        let (_, v2, used) = parse(TESTNET4_HEADERS[0].0);
+        assert!(v2.is_none(), "150,307 is the last SHA256d block");
+        assert_eq!(used, HEADER_V1_SIZE);
+
+        for (hex_str, expected) in TESTNET4_HEADERS.iter() {
+            let (header, v2, _) = parse(hex_str);
+            assert_eq!(block_hash(&header, v2.as_ref()).to_string(), *expected);
+        }
+
+        for (hex_str, _) in TESTNET4_HEADERS.iter().skip(1) {
+            let (_, v2, used) = parse(hex_str);
+            assert_eq!(used, HEADER_V2_SIZE);
+            assert!(v2.is_some());
+        }
+    }
+
+    #[test]
+    fn round_trips_through_serialize() {
+        for (hex_str, expected) in HEADERS.iter() {
+            let (header, v2, _) = parse(hex_str);
+            let bytes = serialize(&header, v2.as_ref());
+
+            assert_eq!(hex::encode(&bytes), *hex_str);
+
+            let (header, v2, _) = parse_header(&bytes).expect("re-parses");
+            assert_eq!(block_hash(&header, v2.as_ref()).to_string(), *expected);
+        }
+    }
+
+    #[test]
+    fn rejects_a_truncated_header() {
+        let bytes = hex::decode(HEADERS[1].0).expect("valid hex");
+        assert!(parse_header(&bytes[..HEADER_V1_SIZE + 4]).is_err());
+    }
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -68,7 +68,10 @@ pub async fn write_to_db(
                 &info.height.to_string(),
                 &network.to_string(),
                 &info.header.block_hash().to_string(),
-                &corepc_client::bitcoin::consensus::encode::serialize_hex(&info.header),
+                &hex::encode(crate::blake2b::serialize(
+                    &info.header,
+                    info.header.v2.as_ref(),
+                )),
                 &info.miner,
             ],
         )?;
@@ -147,7 +150,8 @@ async fn load_header_infos(db: Db, network: u32) -> Result<Vec<HeaderInfo>, DbEr
     while let Some(row) = rows.next()? {
         let header_hex: String = row.get(1)?;
         let header_bytes = hex::decode(&header_hex)?;
-        let header = corepc_client::bitcoin::consensus::deserialize(&header_bytes)?;
+        let (header, v2, _) = crate::blake2b::parse_header(&header_bytes)?;
+        let header = crate::blake2b::ParsedHeader { header, v2 };
         headers.push(HeaderInfo {
             height: row.get::<_, i64>(0)? as u64,
             header,

--- a/src/error.rs
+++ b/src/error.rs
@@ -78,6 +78,7 @@ pub enum DbError {
     Rusqlite(rusqlite::Error),
     DecodeHex(hex::FromHexError),
     BitcoinDeserialize(corepc_client::bitcoin::consensus::encode::Error),
+    HeaderParse(crate::blake2b::ParseError),
 }
 
 impl fmt::Display for DbError {
@@ -86,6 +87,7 @@ impl fmt::Display for DbError {
             DbError::DecodeHex(e) => write!(f, "hex decoding error: {:?}", e),
             DbError::BitcoinDeserialize(e) => write!(f, "Bitcoin deserialization error: {:?}", e),
             DbError::Rusqlite(e) => write!(f, "Rusqlite SQL error: {:?}", e),
+            DbError::HeaderParse(e) => write!(f, "header parse error: {}", e),
         }
     }
 }
@@ -96,7 +98,14 @@ impl error::Error for DbError {
             DbError::DecodeHex(ref e) => Some(e),
             DbError::BitcoinDeserialize(ref e) => Some(e),
             DbError::Rusqlite(ref e) => Some(e),
+            DbError::HeaderParse(_) => None,
         }
+    }
+}
+
+impl From<crate::blake2b::ParseError> for DbError {
+    fn from(e: crate::blake2b::ParseError) -> Self {
+        DbError::HeaderParse(e)
     }
 }
 

--- a/src/headertree.rs
+++ b/src/headertree.rs
@@ -325,7 +325,7 @@ mod tests {
     fn hi(height: u64, header: Header) -> HeaderInfo {
         HeaderInfo {
             height,
-            header,
+            header: header.into(),
             miner: String::new(),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use tokio::time::{interval, sleep, Duration};
 mod activity;
 mod api;
 mod backend;
+mod blake2b;
 mod config;
 mod db;
 mod error;

--- a/src/remote_forkobserver.rs
+++ b/src/remote_forkobserver.rs
@@ -75,7 +75,7 @@ fn header_info_from_json(hij: &HeaderInfoJson) -> Result<HeaderInfo, FetchError>
     }
     Ok(HeaderInfo {
         height: hij.height,
-        header,
+        header: header.into(),
         miner: hij.miner.clone(),
     })
 }
@@ -375,7 +375,7 @@ mod tests {
     fn header_info_json_round_trips_and_verifies_hash() {
         let hi = HeaderInfo {
             height: 1,
-            header: header(BlockHash::all_zeros(), 42),
+            header: header(BlockHash::all_zeros(), 42).into(),
             miner: "Some Pool".to_string(),
         };
         let hij = HeaderInfoJson::new(&hi, 0, usize::MAX);
@@ -388,7 +388,7 @@ mod tests {
     fn header_info_json_tampering_is_rejected() {
         let hi = HeaderInfo {
             height: 1,
-            header: header(BlockHash::all_zeros(), 42),
+            header: header(BlockHash::all_zeros(), 42).into(),
             miner: "".to_string(),
         };
         let hij = HeaderInfoJson::new(&hi, 0, usize::MAX);
@@ -412,12 +412,12 @@ mod tests {
     fn header_infos_from_json_drops_headers_below_min_fork_height() {
         let a = HeaderInfo {
             height: 5,
-            header: header(BlockHash::all_zeros(), 1),
+            header: header(BlockHash::all_zeros(), 1).into(),
             miner: "".to_string(),
         };
         let b = HeaderInfo {
             height: 10,
-            header: header(a.header.block_hash(), 2),
+            header: header(a.header.block_hash(), 2).into(),
             miner: "".to_string(),
         };
         let hijs = vec![
@@ -432,7 +432,7 @@ mod tests {
     fn hi(height: u64, header: Header) -> HeaderInfo {
         HeaderInfo {
             height,
-            header,
+            header: header.into(),
             miner: String::new(),
         }
     }
@@ -710,12 +710,12 @@ mod tests {
         let remote_network_id = 7;
         let root = HeaderInfo {
             height: 0,
-            header: header(BlockHash::all_zeros(), 0),
+            header: header(BlockHash::all_zeros(), 0).into(),
             miner: "".to_string(),
         };
         let child = HeaderInfo {
             height: 1,
-            header: header(root.header.block_hash(), 1),
+            header: header(root.header.block_hash(), 1).into(),
             miner: "Remote Pool".to_string(),
         };
         let header_infos = vec![

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,7 +7,7 @@ use std::time::SystemTime;
 use crate::backend::NodeInfo;
 use crate::config::{Countdown, Network};
 
-use corepc_client::bitcoin::blockdata::block::Header;
+use crate::blake2b::ParsedHeader;
 use corepc_client::bitcoin::BlockHash;
 use corepc_client::types::model::{ChainTips, ChainTipsStatus};
 use log::warn;
@@ -47,7 +47,7 @@ pub type Db = Arc<Mutex<Connection>>;
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct HeaderInfo {
     pub height: u64,
-    pub header: Header,
+    pub header: ParsedHeader,
     pub miner: String,
 }
 
@@ -151,7 +151,7 @@ impl StaleBlockJson {
         StaleBlockJson {
             height: hi.height,
             hash: hi.header.block_hash().to_string(),
-            header: corepc_client::bitcoin::consensus::encode::serialize_hex(&hi.header),
+            header: hex::encode(crate::blake2b::serialize(&hi.header, hi.header.v2.as_ref())),
         }
     }
 }


### PR DESCRIPTION
Bitcoin Knots v29.4.1 hardforks the PoW at mainnet 961,640 and testnet4 150,308. fork-observer can't read those headers, so nodes on that chain sit frozen at the last shared block.

Breakages:

- Headers are 164 bytes post-fork, not 80. `chunks(80)` desyncs and the REST batch fails. Esplora and mempool.space hit the same via `consensus::deserialize`.
- Version bit 31 flags v2 and is masked off before use. Read raw, it breaks the BIP-9 top-bits check.
- v2 hashes with BLAKE2b, so `Header::block_hash()` is wrong for them.

Adds a `blake2b` module that parses both versions, hashes each correctly, and serializes back to exact wire bytes. Headers travel as `ParsedHeader` (`Header` plus v2 fields). It derefs to `Header`, and its inherent `block_hash()` shadows the SHA256d one, so existing call sites stay correct unchanged. Can swap that for an explicit accessor if you prefer: same behavior, bigger diff.

Electrum, btcd and block-dn convert with `.into()`. The Core RPC path fetches the raw header now, since the typed model is fixed at 80 bytes and would silently return the wrong hash.

Scope: ingestion only. `headertree.rs` still ranks tips by cumulative work, so a BLAKE2b branch is tracked and drawn but never active. Ranking across two PoW functions is your call.

Tested against a Knots v29.4.1 testnet4 node across height 150,308: 133 headers ingested, every hash confirmed against the node, restart reloads from SQLite still correct. Unit tests use real headers from both networks. Build, test and fmt pass with `--all-features`.

Every block so far has `flags & 3 == 0`, so the other three hashing variants match the reference implementation but are unverified.
